### PR TITLE
Alexa-Enabled Group Feature Appliance Categories Updates

### DIFF
--- a/oh2.js
+++ b/oh2.js
@@ -584,6 +584,8 @@ function discoverDevices(token, success, failure) {
                       break;
                   case 'Lighting':
                       applianceTypes = ['LIGHT'];
+                      actions = getSwitchableActions(item);
+                      break;
                   case 'Switchable':
                       applianceTypes = ['SWITCH'];
                       actions = getSwitchableActions(item);

--- a/oh2.js
+++ b/oh2.js
@@ -582,6 +582,13 @@ function discoverDevices(token, success, failure) {
                       ];
                       applianceTypes = ['SMARTLOCK'];
                       break;
+                  case 'Outlet':
+                      actions = [
+                          'turnOn',
+                          'turnOff'
+                      ];
+                      applianceTypes = ['SMARTPLUG'];
+                      break;
                   case 'Lighting':
                       applianceTypes = ['LIGHT'];
                       actions = getSwitchableActions(item);


### PR DESCRIPTION
The appliance type for "Lighting" tagged items is current being set to "SWITCH". This is preventing the recently added [Alexa-Enabled Group](https://developer.amazon.com/blogs/alexa/post/0a55ae8a-1f39-411f-a3ca-6a19be80b2f3/now-available-routines-alexa-enabled-groups-and-smart-home-device-state-in-the-amazon-alexa-app) feature, which allows to interact with all items in a specific group based on their appliance type (Alexa, turn off the lights), from working properly.

Apart from the fix, I took the opportunity of adding support for the Alexa Smartplug appliance category which I believe could be used in that same setup. I named the tag for this category "Outlet".