### PR TITLE
Update USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -30,6 +30,7 @@ See the [Hue Emulation](https://www.openhab.org/addons/integrations/hueemulation
   Some examples of tagged items are:
   
   ```java
+  Switch Item_Name(Required) "Item Label"(Required) <Icon Name>(optional) [Tag](Required) {channel="..."}(optional)
   Switch Kitchen_Light "Kitchen Light" <light> (gKitchen) ["Lighting"] {channel="..."}
   Dimmer Bedroom_Light "Bedroom Light" <light> (gBedroom) ["Lighting"] {channel="..."}
   Number Bedroom_Temperature "Bedroom Temperature" (gBedroom) ["CurrentTemperature"] {channel="..."}

--- a/USAGE.md
+++ b/USAGE.md
@@ -45,9 +45,9 @@ See the [Hue Emulation](https://www.openhab.org/addons/integrations/hueemulation
     * The interactive REST API interface available through the openHAB 2 dashboard
     * PaperUI does not yet allow manipulation of tags
 
-#### Item Label Recommendation
+#### Item Label Recommendation and Requirement
 
-Matching of voice commands to Items happens based on the Item label (e.g. "Kitchen Light").
+Matching of voice commands to Items happens based on the Item label (e.g. "Kitchen Light").  (Note: Although, it is valid syntax to not have an item label, the string in quotes following the name.  For this skill to function properly a label is required.)
 It is therefore advisable, to choose labels that can be used to form natural commands.
 As an example, compare "Alexa, turn on the *Kitchen Light*" vs. "Alexa, turn on the *Ground Floor LEDs Kitchen*".
 


### PR DESCRIPTION
This problem has caused many posts on the community forum.  I believe it is because this document sites the items file help as a reference.  In that document it states labels are optional.  However this skill requires them.