### PR TITLE
Adds editable to rest request to get around oh issue here https://com…

### DIFF
--- a/rest.js
+++ b/rest.js
@@ -48,7 +48,7 @@ function getItems(token, success, failure) {
  * Returns all items as just Name and State
  */
 function getItemStates(token, success, failure) {
-    return getItemOrItems(token, null, 'fields=name,state', success, failure);
+    return getItemOrItems(token, null, 'fields=name,state,editable', success, failure);
 }
 
 /**


### PR DESCRIPTION
…munity.openhab.org/t/field-editable-is-required-when-getting-items-on-the-rest-api/65094/5 .

Fixes #126

Signed-off-by: Dan Cunningham <dan@digitaldan.com>