### PR TITLE
 Alexa Response Customization Framework Improvements

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -301,7 +301,8 @@ LIGHT	| Indicates light sources or fixtures.
 MICROWAVE | Indicates a microwave oven endpoint.	 
 MOTION_SENSOR | Indicates an endpoint that detects and reports movement in an area.
 OTHER	| An endpoint that cannot be described in on of the other categories.	 
-SCENE_TRIGGER	|Describes a combination of devices set to a specific state, when the order of the state change is not important. For example a bedtime scene might include turning off lights and lowering the thermostat, but the order is unimportant.	| Applies to Scenes
+SCENE_TRIGGER	| Describes a combination of devices set to a specific state, when the order of the state change is not important. For example a bedtime scene might include turning off lights and lowering the thermostat, but the order is unimportant.	| Applies to Scenes
+SECURITY_PANEL | Indicates a security panel.
 SMARTLOCK	| Indicates an endpoint that locks.	 
 SMARTPLUG	| Indicates modules that are plugged into an existing electrical outlet.	| Can control a variety of devices.
 SPEAKER	| Indicates the endpoint is a speaker or speaker system.	 

--- a/alexaContextProperties.js
+++ b/alexaContextProperties.js
@@ -21,12 +21,12 @@ var AlexaContextProperties = function () {
  */
 AlexaContextProperties.prototype.powerStateProperty = function (state) {
   // Extract brightness level from color item state
-  if (state.split(',').length == 3) {
+  if (state.split(',').length === 3) {
     state = state.split(',').pop();
   }
   if (!isNaN(state)) {
     var num = parseInt(state);
-    state = num > 0 ? "ON" : "OFF"
+    state = num > 0 ? 'ON' : 'OFF'
   }
   return this.generateProperty('Alexa.PowerController', 'powerState', state);
 }
@@ -37,11 +37,11 @@ AlexaContextProperties.prototype.powerStateProperty = function (state) {
  */
 AlexaContextProperties.prototype.percentageStateProperty = function (state) {
   // Extract brightness level from color item state
-  if (state.split(',').length == 3) {
+  if (state.split(',').length === 3) {
     state = state.split(',').pop();
   }
   if (isNaN(state)) {
-    state = state === "ON" ? 100 : 0;
+    state = state === 'ON' ? 100 : 0;
   }
   return this.generateProperty('Alexa.PercentageController', 'percentage', parseInt(state));
 }
@@ -52,11 +52,11 @@ AlexaContextProperties.prototype.percentageStateProperty = function (state) {
  */
 AlexaContextProperties.prototype.brightnessStateProperty = function (state) {
   // Extract brightness level from color item state
-  if (state.split(',').length == 3) {
+  if (state.split(',').length === 3) {
     state = state.split(',').pop();
   }
   if (isNaN(state)) {
-    state = state === "ON" ? 100 : 0;
+    state = state === 'ON' ? 100 : 0;
   }
   return this.generateProperty('Alexa.BrightnessController', 'brightness', parseInt(state));
 }
@@ -67,7 +67,7 @@ AlexaContextProperties.prototype.brightnessStateProperty = function (state) {
  */
 AlexaContextProperties.prototype.powerLevelStateProperty = function (state) {
   if (isNaN(state)) {
-    state = state === "ON" ? 100 : 0;
+    state = state === 'ON' ? 100 : 0;
   }
   return this.generateProperty('Alexa.PowerLevelController', 'powerLevel', parseInt(state));
 }
@@ -188,7 +188,7 @@ AlexaContextProperties.prototype.inputStateProperty = function (state) {
  * @param {string} state
  */
 AlexaContextProperties.prototype.speakerMutedStateProperty = function (state) {
-  var muted = state === "ON" ? true : false;
+  var muted = state === 'ON' ? true : false;
   return this.generateProperty('Alexa.Speaker', 'muted', muted);
 }
 
@@ -221,7 +221,7 @@ AlexaContextProperties.prototype.motionSensorStateProperty = function (state) {
  */
 AlexaContextProperties.prototype.endpointHealthProperty = function () {
   return this.generateProperty('Alexa.EndpointHealth', 'connectivity', {
-    value: "OK"
+    value: 'OK'
   });
 }
 
@@ -254,48 +254,48 @@ AlexaContextProperties.prototype.propertiesResponseForInterfaces = function (int
   interfaceNames.forEach(function (interfaceName) {
     var properties = propertyMap[interfaceName];
     switch (interfaceName) {
-      case "PowerController": //Switch, Dimmer [Switchable]
+      case 'PowerController': //Switch, Dimmer [Switchable]
         var item = properties.powerState.item;
         response.push(self.powerStateProperty(item.state));
         break;
-      case "PowerLevelController": //Dimmer or Number, Rollershutter [Lighting]
+      case 'PowerLevelController': //Dimmer or Number, Rollershutter [Lighting]
         var item = properties.powerLevel.item;
         response.push(self.powerLevelStateProperty(item.state));
         break;
-      case "BrightnessController":
+      case 'BrightnessController':
         var item = properties.brightness.item;
         response.push(self.brightnessStateProperty(item.state));
         break;
-      case "PercentageController":
+      case 'PercentageController':
         var item = properties.percentage.item;
         response.push(self.percentageStateProperty(item.state));
         break;
-      case "ColorController": //Color [Lighting]
+      case 'ColorController': //Color [Lighting]
         var item = properties.color.item;
         response.push(self.colorStateProperty(item.state));
         break;
-      case "ColorTemperatureController": //Dimmer or Number
+      case 'ColorTemperatureController': //Dimmer or Number
         var item = properties.colorTemperatureInKelvin.item;
         var state = utils.normalizeColorTemperature(item.state, item.type);
         response.push(self.colorTemperatureStateProperty(state));
         break;
-      case "ThermostatController": //Group [Thermostat]
+      case 'ThermostatController': //Group [Thermostat]
         if (properties.targetSetpoint) {
           var item = properties.targetSetpoint.item;
           var scale = properties.targetSetpoint.parameters.scale ?
-            properties.targetSetpoint.parameters.scale.toUpperCase() : "CELSIUS";
+            properties.targetSetpoint.parameters.scale.toUpperCase() : 'CELSIUS';
           response.push(self.targetSetpointStateProperty(item.state, scale));
         }
         if (properties.upperSetpoint) {
           var item = properties.upperSetpoint.item;
           var scale = properties.upperSetpoint.parameters.scale ?
-            properties.upperSetpoint.parameters.scale.toUpperCase() : "CELSIUS";
+            properties.upperSetpoint.parameters.scale.toUpperCase() : 'CELSIUS';
           response.push(self.upperSetpointStateProperty(item.state, scale));
         }
         if (properties.lowerSetpoint) {
           var item = properties.lowerSetpoint.item;
           var scale = properties.lowerSetpoint.parameters.scale ?
-            properties.lowerSetpoint.parameters.scale.toUpperCase() : "CELSIUS";
+            properties.lowerSetpoint.parameters.scale.toUpperCase() : 'CELSIUS';
           response.push(self.lowerSetpointStateProperty(item.state, scale));
         }
         if (properties.thermostatMode) {
@@ -304,29 +304,29 @@ AlexaContextProperties.prototype.propertiesResponseForInterfaces = function (int
           response.push(self.thermostatModeStateProperty(state));
         }
         break;
-      case "TemperatureSensor":
+      case 'TemperatureSensor':
         var item = properties.temperature.item;
         var scale = properties.temperature.parameters.scale ?
-          properties.temperature.parameters.scale.toUpperCase() : "CELSIUS";
+          properties.temperature.parameters.scale.toUpperCase() : 'CELSIUS';
         response.push(self.temperatureSensorStateProperty(item.state, scale));
         break;
-      case "LockController": //Switch [Lock]
+      case 'LockController': //Switch [Lock]
         var state = utils.normalizePropertyState('lockState', properties.lockState);
         response.push(self.lockStateProperty(state));
         break;
-      case "ChannelController": //Number [Alexa@Channel]
+      case 'ChannelController': //Number [Alexa@Channel]
         var item = properties.channel.item;
         response.push(self.channelStateProperty(item.state));
         break;
-      case "InputController": //String [Alexa@Input]
+      case 'InputController': //String [Alexa@Input]
         var item = properties.input.item;
         response.push(self.inputStateProperty(item.state));
         break;
-      case "PlaybackController": //Player or Group? [Alexa@Player]
+      case 'PlaybackController': //Player or Group? [Alexa@Player]
         break;
-      case "SceneController": //Switch ? [Scene]
+      case 'SceneController': //Switch ? [Scene]
         break;
-      case "Speaker": //Group ? (volume dimmer, mute switch) [Alexa@Speaker]
+      case 'Speaker': //Group ? (volume dimmer, mute switch) [Alexa@Speaker]
         if (properties.muted) {
           var item = properties.muted.item;
           response.push(self.speakerMutedStateProperty(item.state));
@@ -336,15 +336,15 @@ AlexaContextProperties.prototype.propertiesResponseForInterfaces = function (int
           response.push(self.speakerVolumeStateProperty(item.state));
         }
         break;
-      case "StepSpeaker": //Group ? (steup string, mute, not really sure) [Alexa@StepSpeaker]
+      case 'StepSpeaker': //Group ? (steup string, mute, not really sure) [Alexa@StepSpeaker]
         break;
-      case "CameraStreamController":  //not supported.
+      case 'CameraStreamController':  //not supported.
         break;
-      case "ContactSensor":
+      case 'ContactSensor':
         var state = utils.normalizePropertyState('detectionState', properties.detectionState);
         response.push(self.contactSensorStateProperty(state));
         break;
-      case "MotionSensor":
+      case 'MotionSensor':
         var state = utils.normalizePropertyState('detectionState', properties.detectionState);
         response.push(self.motionSensorStateProperty(state));
         break;

--- a/alexaPropertyMap.js
+++ b/alexaPropertyMap.js
@@ -212,7 +212,7 @@ AlexaPropertyMap.prototype.getItemsByInterfaces = function(interfaceNames) {
       var item = properties[propertyName].item;
       var index = items.findIndex(i => i.name === item.name);
 
-       if (index == -1) {
+       if (index === -1) {
         items.push(Object.assign(item, {capabilities: [capability]}));
       } else {
         items[index].capabilities.push(capability);

--- a/log.js
+++ b/log.js
@@ -1,6 +1,6 @@
 const winston = require('winston');
 
-let setLevel = typeof (process.env.LOG_LEVEL) !== 'undefined' ? process.env.LOG_LEVEL.toLowerCase() : "debug";
+let setLevel = typeof (process.env.LOG_LEVEL) !== 'undefined' ? process.env.LOG_LEVEL.toLowerCase() : 'debug';
 
 const logger = winston.createLogger({
     level: setLevel,

--- a/ohConnectorV3.js
+++ b/ohConnectorV3.js
@@ -44,38 +44,38 @@ exports.handleRequest = function (_directive, _callback) {
   var name = directive.header.name; // ex: AdjustBrightness
 
   switch (namespace) {
-    case "Alexa":
+    case 'Alexa':
       switch (name) {
         case 'ReportState':
           reportState();
       }
       break;
-    case "Alexa.Discovery":
+    case 'Alexa.Discovery':
       discoverDevices();
       break;
-    case "Alexa.PowerController":
+    case 'Alexa.PowerController':
       setPowerState();
       break;
-    case "Alexa.PowerLevelController":
-    case "Alexa.BrightnessController":
-    case "Alexa.PercentageController":
+    case 'Alexa.PowerLevelController':
+    case 'Alexa.BrightnessController':
+    case 'Alexa.PercentageController':
       adjustPercentage();
       break;
-    case "Alexa.ColorController":
+    case 'Alexa.ColorController':
       setColor();
       break;
-    case "Alexa.ColorTemperatureController":
+    case 'Alexa.ColorTemperatureController':
       switch(name) {
-        case "SetColorTemperature":
+        case 'SetColorTemperature':
           setColorTemperature();
           break;
-        case "DecreaseColorTemperature":
-        case "IncreaseColorTemperature":
+        case 'DecreaseColorTemperature':
+        case 'IncreaseColorTemperature':
           adjustColorTemperature();
           break;
       }
       break;
-    case "Alexa.ThermostatController":
+    case 'Alexa.ThermostatController':
       switch (name) {
         case 'AdjustTargetTemperature':
           adjustTargetTemperature();
@@ -88,10 +88,10 @@ exports.handleRequest = function (_directive, _callback) {
           break;
       }
       break;
-    case "Alexa.LockController":
+    case 'Alexa.LockController':
       setLockState();
       break;
-    case "Alexa.ChannelController":
+    case 'Alexa.ChannelController':
       switch (name) {
         case 'ChangeChannel':
           setChannel();
@@ -101,46 +101,46 @@ exports.handleRequest = function (_directive, _callback) {
           break;
       }
       break;
-    case "Alexa.InputController":
+    case 'Alexa.InputController':
       setInput();
       break;
-    case "Alexa.PlaybackController":
+    case 'Alexa.PlaybackController':
       setPlayback();
       break;
-    case "Alexa.SceneController":
+    case 'Alexa.SceneController':
       setScene();
       break;
-    case "Alexa.Speaker":
+    case 'Alexa.Speaker':
       switch (name) {
-        case "AdjustVolume":
+        case 'AdjustVolume':
           adjustSpeakerVolume();
           break;
-        case "SetVolume":
+        case 'SetVolume':
           setSpeakerVolume();
           break;
-        case "SetMute":
+        case 'SetMute':
           setSpeakerMute();
           break;
       }
       break;
-    case "Alexa.StepSpeaker":
+    case 'Alexa.StepSpeaker':
       switch (name) {
-        case "AdjustVolume":
+        case 'AdjustVolume':
           adjustStepSpeakerVolume();
           break;
-        case "SetMute":
+        case 'SetMute':
           setStepSpeakerMute();
           break;
       }
       break;
-    case "Alexa.CameraStreamController":
+    case 'Alexa.CameraStreamController':
       break;
     default:
   }
 };
 
 /**
- * Answers a "ReportState" request.  Returns the state(s) of an endpoint
+ * Answers a 'ReportState' request.  Returns the state(s) of an endpoint
  */
 function reportState() {
   // Generate properties response based on property map received
@@ -168,32 +168,32 @@ function adjustPercentage() {
   var payloadValue;
 
   switch (directive.header.name) {
-    case "AdjustPowerLevel":
+    case 'AdjustPowerLevel':
       isSetCommand = false;
       propertyName = 'powerLevel';
       payloadValue = directive.payload.powerLevelDelta;
       break;
-    case "SetPowerLevel":
+    case 'SetPowerLevel':
       isSetCommand = true;
       propertyName = 'powerLevel';
       payloadValue = directive.payload.powerLevel;
       break;
-    case "AdjustPercentage":
+    case 'AdjustPercentage':
       isSetCommand = false;
       propertyName = 'percentage';
       payloadValue = directive.payload.percentageDelta;
       break;
-    case "SetPercentage":
+    case 'SetPercentage':
       isSetCommand = true;
       propertyName = 'percentage';
       payloadValue = directive.payload.percentage;
       break;
-    case "AdjustBrightness":
+    case 'AdjustBrightness':
       isSetCommand = false;
       propertyName = 'brightness';
       payloadValue = directive.payload.brightnessDelta;
       break;
-    case "SetBrightness":
+    case 'SetBrightness':
       isSetCommand = true;
       propertyName = 'brightness';
       payloadValue = directive.payload.brightness;
@@ -332,8 +332,8 @@ function setTargetTemperature() {
   if (directive.payload.targetSetpoint && !directive.payload.upperSetpoint && !directive.payload.lowerSetpoint &&
     !properties.targetSetpoint && properties.upperSetpoint && properties.lowerSetpoint) {
     // default range if not set
-    var upperRange = properties.upperSetpoint.parameters.scale == 'FAHRENHEIT' ? 1 : .5;
-    var lowerRange = properties.lowerSetpoint.parameters.scale == 'FAHRENHEIT' ? 1 : .5;
+    var upperRange = properties.upperSetpoint.parameters.scale === 'FAHRENHEIT' ? 1 : .5;
+    var lowerRange = properties.lowerSetpoint.parameters.scale === 'FAHRENHEIT' ? 1 : .5;
     // use user defined comfort range if set
     if (typeof properties.upperSetpoint.parameters.comfort_range !== 'undefined') {
       upperRange = parseFloat(properties.upperSetpoint.parameters.comfort_range);
@@ -354,7 +354,7 @@ function setTargetTemperature() {
     );
   }
 
-  log.debug('setTargetTemperature to values: ', JSON.stringify(postItems));
+  log.debug('setTargetTemperature to values:', JSON.stringify(postItems));
   postItemsAndReturn(postItems, 'ThermostatController');
 }
 
@@ -368,9 +368,9 @@ function adjustTargetTemperature() {
 
   // adjust target setpoint if defined otherwise upper/lower setpoints if in dual mode
   if (properties.targetSetpoint) {
-    propertyNames.push("targetSetpoint");
+    propertyNames.push('targetSetpoint');
   } else if (properties.upperSetpoint && properties.lowerSetpoint) {
-    propertyNames.push("upperSetpoint", "lowerSetpoint");
+    propertyNames.push('upperSetpoint', 'lowerSetpoint');
   }
   propertyNames.forEach(function (propertyName) {
     promises.push(new Promise(function (resolve, reject) {
@@ -386,10 +386,10 @@ function adjustTargetTemperature() {
     }));
   })
   Promise.all(promises).then(function (postItems) {
-    log.debug('adjustTargetTemperature to values: ', JSON.stringify(postItems));
+    log.debug('adjustTargetTemperature to values:', JSON.stringify(postItems));
     postItemsAndReturn(postItems, 'ThermostatController');
   }).catch(function (error) {
-    log.debug('adjustTargetTemperature failed with error: ' + JSON.stringify(error));
+    log.debug('adjustTargetTemperature failed with error:', JSON.stringify(error));
     returnAlexaResponse(generateGenericErrorResponse());
   });
 }
@@ -408,9 +408,8 @@ function setThermostatMode() {
     postItemsAndReturn([postItem], 'ThermostatController');
   } else {
     returnAlexaResponse(generateControlError({
-      type: "UNSUPPORTED_THERMOSTAT_MODE",
-      message: postItem.name + " doesn't support thermostat mode [" +
-        directive.payload.thermostatMode.value + "]",
+      type: 'UNSUPPORTED_THERMOSTAT_MODE',
+      message: `${postItem.name} doesn't support thermostat mode [${directive.payload.thermostatMode.value}]`,
     }, directive.header.namespace));
   }
 }
@@ -573,7 +572,7 @@ function adjustStepSpeakerVolume() {
  */
 function setStepSpeakerMute() {
   var postItem = Object.assign(propertyMap.StepSpeaker.muted.item, {
-    state: directive.payload.mute ? "ON" : "OFF"
+    state: directive.payload.mute ? 'ON' : 'OFF'
   });
   postItemsAndReturn([postItem], 'StepSpeaker');
 }
@@ -585,7 +584,7 @@ function setStepSpeakerMute() {
  *
  * @param {Array}  items
  * @param {String} interfaceName
- * @param {Object} parameters     Additonal parameters [header, payload, response] (optional)
+ * @param {Object} parameters     Additional parameters [header, payload, response] (optional)
  */
 function postItemsAndReturn(items, interfaceName, parameters = {}) {
   var promises = [];
@@ -595,13 +594,13 @@ function postItemsAndReturn(items, interfaceName, parameters = {}) {
   });
   Promise.all(promises).then(function () {
     if (parameters.response) {
-      log.debug('postItemsAndReturn done with response: ' + JSON.stringify(parameters.response));
+      log.debug('postItemsAndReturn done with response:', JSON.stringify(parameters.response));
       returnAlexaResponse(parameters.response);
     } else {
       getPropertiesResponseAndReturn(interfaceName, parameters);
     }
   }).catch(function (error) {
-    log.debug('postItemsAndReturn failed with error: ' + JSON.stringify(error));
+    log.debug('postItemsAndReturn failed with error:', JSON.stringify(error));
     returnAlexaResponse(generateGenericErrorResponse());
   });
 }
@@ -612,7 +611,7 @@ function postItemsAndReturn(items, interfaceName, parameters = {}) {
  *  and then return a formatted response to the Alexa request
  *
  * @param {String} interfaceName
- * @param {Object} parameters     Additonal parameters [header, payload, response] (optional)
+ * @param {Object} parameters     Additional parameters [header, payload, response] (optional)
  */
 function getPropertiesResponseAndReturn(interfaceName, parameters = {}) {
   // Use the property map defined interface names if interfaceName not defined (e.g. reportState)
@@ -658,11 +657,11 @@ function getPropertiesResponseAndReturn(interfaceName, parameters = {}) {
         payload: parameters.payload || {}
       }
     };
-    log.debug('getPropertiesResponseAndReturn done with response: ' + JSON.stringify(response));
+    log.debug('getPropertiesResponseAndReturn done with response:', JSON.stringify(response));
     returnAlexaResponse(response);
 
   }).catch(function (error) {
-    log.debug('getPropertiesResponseAndReturn failed with error: ' + JSON.stringify(error));
+    log.debug('getPropertiesResponseAndReturn failed with error:', JSON.stringify(error));
     returnAlexaResponse(generateGenericErrorResponse());
   });
 }
@@ -712,7 +711,7 @@ function generateControlError(payload, namespace) {
     response.event.endpoint = directive.endpoint;
   }
 
-  log.debug('generateControlError done with response' + JSON.stringify(response));
+  log.debug('generateControlError done with response:', JSON.stringify(response));
   return response;
 }
 
@@ -722,8 +721,8 @@ function generateControlError(payload, namespace) {
  */
 function generateGenericErrorResponse() {
   return generateControlError({
-    type: "ENDPOINT_UNREACHABLE",
-    message: "Unable to reach device"
+    type: 'ENDPOINT_UNREACHABLE',
+    message: 'Unable to reach device'
   });
 }
 
@@ -737,11 +736,11 @@ function discoverDevices() {
     //items here are part of a group and should not be added individually
     var groupItems = [];
 
-    //log.debug("GET ITEMS: " + JSON.stringify(items));
+    //log.debug('GET ITEMS:', JSON.stringify(items));
 
     //convert v2 style label/tag to v3
     convertV2Items(items);
-    //log.debug("Items: " + JSON.stringify(items));
+    //log.debug('Items:', JSON.stringify(items));
     items.forEach(function (item) {
       //this item is already part of a group
       if (groupItems.includes(item.name)) {
@@ -767,10 +766,10 @@ function discoverDevices() {
           //found matching Endpoint capability
           var groupMatch;
           if (groupMatch = capability.match(ENDPOINT_PATTERN)) {
-            log.debug("found group " + groupMatch[0] + " for item " + item.name);
+            log.debug('found group ' + groupMatch[0] + ' for item ' + item.name);
             isEndpointGroup = true;
             item.members.forEach(function (member) {
-              log.debug("adding  " + member.name + " to group " + item.name);
+              log.debug('adding  ' + member.name + ' to group ' + item.name);
               groupItems.push(member.name);
               propertyMap.addItem(member);
             });
@@ -786,11 +785,11 @@ function discoverDevices() {
       }
 
       //no capability found
-      if (Object.keys(propertyMap).length == 0) {
+      if (Object.keys(propertyMap).length === 0) {
         return;  //just returns forEach function
       }
 
-      log.debug("Property Map: " + JSON.stringify(propertyMap));
+      log.debug('Property Map:', JSON.stringify(propertyMap));
 
       capabilities.push(alexaCapabilities.alexa());
 
@@ -798,59 +797,59 @@ function discoverDevices() {
         var properties = propertyMap[interfaceName];
         var capability;
         switch (interfaceName) {
-          case "PowerController":
+          case 'PowerController':
             capability = alexaCapabilities.powerController();
             break;
-          case "BrightnessController":
+          case 'BrightnessController':
             capability = alexaCapabilities.brightnessController();
             break;
-          case "PowerLevelController":
+          case 'PowerLevelController':
             capability = alexaCapabilities.powerLevelController();
             break;
-          case "PercentageController":
+          case 'PercentageController':
             capability = alexaCapabilities.percentageController();
             break;
-          case "ColorController":
+          case 'ColorController':
             capability = alexaCapabilities.colorController();
             break;
-          case "ColorTemperatureController":
+          case 'ColorTemperatureController':
             capability = alexaCapabilities.colorTemperatureController();
             break;
-          case "TemperatureSensor":
+          case 'TemperatureSensor':
             capability = alexaCapabilities.temperatureSensor();
             break;
-          case "ThermostatController":
+          case 'ThermostatController':
             capability = alexaCapabilities.thermostatController(properties.targetSetpoint,
               properties.upperSetpoint, properties.lowerSetpoint, properties.thermostatMode);
             break;
-          case "Speaker":
+          case 'Speaker':
             capability = alexaCapabilities.speaker(properties.volume, properties.muted);
             break;
-          case "StepSpeaker":
+          case 'StepSpeaker':
             capability = alexaCapabilities.stepSpeaker();
             break;
-          case "LockController":
+          case 'LockController':
             capability = alexaCapabilities.lockController();
             break;
-          case "CameraStreamController":
+          case 'CameraStreamController':
             capability = alexaCapabilities.cameraStreamController(properties.cameraStreamConfigurations);
             break;
-          case "SceneController":
+          case 'SceneController':
             capability = alexaCapabilities.sceneController(properties.scene);
             break;
-          case "ChannelController":
+          case 'ChannelController':
             capability = alexaCapabilities.channelController();
             break;
-          case "InputController":
+          case 'InputController':
             capability = alexaCapabilities.inputController();
             break;
-          case "PlaybackController":
+          case 'PlaybackController':
             capability = alexaCapabilities.playbackController();
             break;
-          case "ContactSensor":
+          case 'ContactSensor':
             capability = alexaCapabilities.contactSensor();
             break;
-          case "MotionSensor":
+          case 'MotionSensor':
             capability = alexaCapabilities.motionSensor();
             break;
           default:
@@ -858,7 +857,7 @@ function discoverDevices() {
         }
 
         if (capability) {
-          //log.debug("interfaceName: " + interfaceName + " capability: " + JSON.stringify(capability));
+          //log.debug(`interfaceName: ${interfaceName} capability:`, JSON.stringify(capability));
           capabilities.push(capability.capabilities);
           // add properties or capability categories if not endpoint group item
           if (!isEndpointGroup) {
@@ -888,7 +887,7 @@ function discoverDevices() {
 
     var header = {
       messageId: directive.header.messageId,
-      name: "Discover.Response",
+      name: 'Discover.Response',
       namespace: directive.header.namespace,
       payloadVersion: directive.header.payloadVersion
     };
@@ -914,10 +913,10 @@ function discoverDevices() {
       }
     };
 
-    log.debug('Discovery: ' + JSON.stringify(response));
+    log.debug('Discovery:', JSON.stringify(response));
     returnAlexaResponse(response);
   }).catch(function (error) {
-    log.error("discoverDevices failed: " + error.message);
+    log.error('discoverDevices failed: ' + error.message);
     returnAlexaResponse(generateGenericErrorResponse());
   });
 }
@@ -1092,23 +1091,23 @@ function getV2SwitchableCapabilities(item) {
   switch (item.type === 'Group' ? item.groupType : item.type) {
     case 'Switch':
       return [
-        "PowerController.powerState"
+        'PowerController.powerState'
       ];
     case 'Dimmer':
       return [
-        "PowerController.powerState",
-        "BrightnessController.brightness"
+        'PowerController.powerState',
+        'BrightnessController.brightness'
       ];
     case 'Color':
       return [
-        "PowerController.powerState",
-        "BrightnessController.brightness",
-        "ColorController.color"
+        'PowerController.powerState',
+        'BrightnessController.brightness',
+        'ColorController.color'
       ];
     case 'Rollershutter':
       return [
-        "PowerController.powerState",
-        "PercentageController.percentage"
+        'PowerController.powerState',
+        'PercentageController.percentage'
       ];
     default:
       return [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "ast-types": {
@@ -270,7 +270,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -283,7 +283,7 @@
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
       "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
@@ -319,7 +319,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -328,7 +328,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
     "buffer": {
@@ -515,7 +515,7 @@
     "continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "integrity": "sha1-EfYT906RT+mzTJKtLSj+auHbf/s=",
       "requires": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
@@ -603,15 +603,30 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "requires": {
         "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "requires": {
+        "xregexp": "4.0.0"
+      },
+      "dependencies": {
+        "xregexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+          "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+        }
       }
     },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -658,7 +673,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "dotenv": {
@@ -695,7 +710,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "optional": true,
       "requires": {
         "once": "^1.4.0"
@@ -806,7 +821,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "optional": true
     },
     "forever-agent": {
@@ -827,7 +842,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
       "optional": true
     },
     "fs-extra": {
@@ -932,7 +947,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -950,7 +965,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "har-schema": {
@@ -994,7 +1009,7 @@
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -1013,7 +1028,7 @@
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -1233,7 +1248,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1275,7 +1290,7 @@
         "commander": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
           "dev": true
         }
       }
@@ -1294,7 +1309,7 @@
     "node-lambda": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/node-lambda/-/node-lambda-0.11.7.tgz",
-      "integrity": "sha512-1qvfYWJyLLVB3PxDSlEHVoTT4JsBdSkrFmCdpvbH0ghxd+EwssPkxATIO2hVvhAzDCSnaCxg0lSxZd8oG6xSVw==",
+      "integrity": "sha1-Lz4bxnM7sdphFzXBRsa6t5wroec=",
       "optional": true,
       "requires": {
         "archiver": "^2.1.1",
@@ -1351,7 +1366,7 @@
     "pac-proxy-agent": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
-      "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+      "integrity": "sha1-kNn2cwqw9NJgfc3NTT1kGqJsOJY=",
       "optional": true,
       "requires": {
         "agent-base": "^4.2.0",
@@ -1367,7 +1382,7 @@
     "pac-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
       "optional": true,
       "requires": {
         "co": "^4.6.0",
@@ -1407,12 +1422,12 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "proxy-agent": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
-      "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
+      "integrity": "sha1-PUnYY9Rs9fN8qDlISDRuoCNz6sY=",
       "optional": true,
       "requires": {
         "agent-base": "^4.2.0",
@@ -1579,7 +1594,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1632,7 +1647,7 @@
     "socks-proxy-agent": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+      "integrity": "sha1-Lq58+OKoLTRWV2FTmn+XGMVhdlk=",
       "requires": {
         "agent-base": "^4.1.0",
         "socks": "^1.1.10"
@@ -1641,7 +1656,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "optional": true
     },
     "sprintf-js": {
@@ -1692,7 +1707,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "^2.0.0"
@@ -1753,7 +1768,7 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
       "optional": true
     },
     "tough-cookie": {
@@ -1801,7 +1816,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "unpipe": {
@@ -1843,7 +1858,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "NODE_ENV=test LOG_LEVEL=error ./node_modules/mocha/bin/mocha --reporter spec test/*.js"
   },
   "dependencies": {
+    "decamelize": "^2.0.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "sprintf-js": "^1.1.2",

--- a/rest.js
+++ b/rest.js
@@ -33,7 +33,7 @@ function getConfig() {
   );
   // Merge username & password if specified
   if (config.openhab.user && config.openhab.pass) {
-    config.openhab.userpass = config.openhab.user + ":" + config.openhab.pass;
+    config.openhab.userpass = `${config.openhab.user}:${config.openhab.pass}`;
   }
   return config;
 }
@@ -83,7 +83,7 @@ function getItemsRecursively(token) {
  */
 function getItemOrItems(token, itemName, parameters) {
   var options = {
-    method: "GET",
+    method: 'GET',
     uri: `${config.openhab.baseURL}/items${itemName ? '/' + itemName : ''}${parameters ? '?' + qs.stringify(parameters) : ''}`,
     headers: {
       'Authorization': ohAuthorizationHeader(token),
@@ -105,7 +105,7 @@ function getItemOrItems(token, itemName, parameters) {
 function postItemCommand(token, itemName, value) {
   var data = value.toString();
   var options = {
-    method: "POST",
+    method: 'POST',
     uri: `${config.openhab.baseURL}/items/${itemName}`,
     headers: {
       'Authorization': ohAuthorizationHeader(token),
@@ -116,7 +116,7 @@ function postItemCommand(token, itemName, value) {
   if (itemName) {
     return request(options);
   } else {
-    return Promise.reject("No item name provided");
+    return Promise.reject('No item name provided');
   }
 }
 module.exports.getItem = getItem;

--- a/test/common.js
+++ b/test/common.js
@@ -15,27 +15,27 @@ var assert = require('chai').assert;
  */
 function generateDirectiveRequest(request) {
   var template = {
-    "header": {
-      "namespace": null,
-      "name": null,
-      "messageId": "message-id",
-      "correlationToken": "correlation-token",
-      "payloadVersion": "3"
+    'header': {
+      'namespace': null,
+      'name': null,
+      'messageId': 'message-id',
+      'correlationToken': 'correlation-token',
+      'payloadVersion': '3'
     },
-    "endpoint": {
-      "endpointId": null,
-      "cookie": {},
-      "scope": {
-        "type": "BearerToken",
-        "token": "access-token-from-skill"
+    'endpoint': {
+      'endpointId': null,
+      'cookie': {},
+      'scope': {
+        'type': 'BearerToken',
+        'token': 'access-token-from-skill'
       }
     },
-    "payload": {}
+    'payload': {}
   };
   var directive = {
-    "header": Object.assign(template.header, request.header),
-    "endpoint": Object.assign(template.endpoint, request.endpoint),
-    "payload": Object.assign(template.payload, request.payload)
+    'header': Object.assign(template.header, request.header),
+    'endpoint': Object.assign(template.endpoint, request.endpoint),
+    'payload': Object.assign(template.payload, request.payload)
   };
   // remove endpoint if no id defined
   if (directive.endpoint.endpointId === null) {

--- a/test/test_ohConnectorV3.js
+++ b/test/test_ohConnectorV3.js
@@ -80,7 +80,7 @@ describe('ohConnectorV3 Tests', function () {
             ohv3.handleRequest(utils.generateDirectiveRequest(test.directive), callback);
             // Wait for async functions
             setTimeout(function() {
-              // console.log("Capture: " + JSON.stringify(capture, null, 2));
+              // console.log("Capture:", JSON.stringify(capture, null, 2));
               assert.capturedCalls(capture.calls, test.expected.openhab);
               assert.capturedResult(capture.result, test.expected.alexa);
               done();

--- a/test/v3/test_controllerColorTemperature.js
+++ b/test/v3/test_controllerColorTemperature.js
@@ -203,7 +203,7 @@ module.exports = [
       alexa: {
         "event": {
           "header": {
-            "namespace": "Alexa",
+            "namespace": "Alexa.ColorTemperatureController",
             "name": "ErrorResponse"
           },
           "payload": {

--- a/test/v3/test_controllerThermostatMode.js
+++ b/test/v3/test_controllerThermostatMode.js
@@ -174,7 +174,7 @@ module.exports = [
       alexa: {
         "event": {
           "header": {
-            "namespace": "Alexa",
+            "namespace": "Alexa.ThermostatController",
             "name": "ErrorResponse"
           },
           "payload": {

--- a/utils.js
+++ b/utils.js
@@ -104,7 +104,7 @@ function normalizeThermostatMode(mode, parameters = {}) {
 
 /**
  * Normalizes temperature scale between Alexa value and OH expected scale
- *    Temperature e.g. {value: 21.5, scale: "CELSIUS"}
+ *    Temperature e.g. {value: 21.5, scale: 'CELSIUS'}
  *
  * @param  {Object}  temperature
  * @param  {String}  scale

--- a/utils.js
+++ b/utils.js
@@ -14,8 +14,8 @@ var sprintf = require('sprintf-js').sprintf;
  */
 var DISPLAY_CATEGORIES = [
   'ACTIVITY_TRIGGER', 'CAMERA', 'CONTACT_SENSOR', 'DOOR', 'DOORBELL', 'LIGHT', 'MICROWAVE',
-  'MOTION_SENSOR', 'OTHER', 'SCENE_TRIGGER', 'SMARTLOCK', 'SMARTPLUG', 'SPEAKER', 'SWITCH',
-  'TEMPERATURE_SENSOR', 'THERMOSTAT', 'TV'
+  'MOTION_SENSOR', 'OTHER', 'SCENE_TRIGGER', 'SECURITY_PANEL', 'SMARTLOCK', 'SMARTPLUG',
+  'SPEAKER', 'SWITCH', 'TEMPERATURE_SENSOR', 'THERMOSTAT', 'TV'
 ];
 
 /**
@@ -29,7 +29,7 @@ var ITEM_TYPE_CAPABILITIES = {
   'ContactSensor':              {'detectionState': ['Contact', 'Switch']},
   'InputController':            {'input': ['Number', 'String']},
   'LockController':             {'lockState': ['Switch']},
-  'MotionSensor':              {'detectionState': ['Contact', 'Switch']},
+  'MotionSensor':               {'detectionState': ['Contact', 'Switch']},
   'PercentageController':       {'percentage': ['Dimmer', 'Rollershutter']},
   'PlaybackController':         {'playback': ['Player']},
   'PowerController':            {'powerState': ['Color', 'Dimmer', 'Rollershutter', 'Switch']},
@@ -188,7 +188,7 @@ function normalizePropertyState(name, property) {
  * @return {String}
  */
 function normalizeItemState(item) {
-  var pattern = item.stateDescription ? item.stateDescription.pattern : undefined;
+  var pattern = item.stateDescription && item.stateDescription.pattern;
   var state = item.state;
   var type = item.type.split(':')[0];
 


### PR DESCRIPTION
Changes allowing to specify custom header name/namespace and payload to be sent in Alexa response. Includes support for camel case endpoint group names. This will become handy for #111 and other complex capabilities.

Corrected the namespace on interface specific error response messages in the process along with some minor code cleanup.

On a side note, what version of npm are you using? I noticed that you are pushing `sha1` hashes while mine is generating `sha512`.

```
$ npm --version
6.4.1
```