### PR TITLE
Security Panel Controller Support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -30,12 +30,47 @@ Hue Emulation exposes openHAB items as Hue devices to other Hue HTTP API compati
 * Amazon account
 * Amazon Echo, Amazon Echo Dot or compatible Alexa device
 
+## Troubleshooting
+
+Here are some of the most common generic errors you may encounter while using this skill:
+
+#### Command Not Working
+* Alexa will respond with "That command doesn't work on _device_"
+* It indicates that the command that Alexa is trying to send to openHAB doesn't work, either because the intended device is not configured properly to support that command or because your openHAB items configuration has changed and a previously discovered item may longer accept certain commands. For example, a dimmer item type that was initially setup and was changed to a switch type, will cause Alexa brightness control commands to fail.
+* To resolve this error, make sure to update your openHAB items configuration accordingly and run a discovery update either through the Alexa app or just by asking "Alexa, discover" on your echo device.
+
+#### Device Not Found
+* Alexa will respond with "I couldn't find a device or group named _device_ in your profile"
+* It indicates that, either a device currently setup in your Alexa account, no longer exists in your openHAB server, or vice-versa.
+* To resolve this error, make sure to run a discovery update either through the Alexa app or just by asking "Alexa, discover" on your echo device. Keep in mind that previously discovered devices that have been removed from the openHAB configuration will show as offline under your Alexa account and not be automatically removed. To prevent potential device name conflicts, it is highly recommended to remove these devices through the Alexa app.
+
+#### Device Not Responding
+* Alexa will respond with "_device_ isn't responding, please check its network connection and power supply", and in some rare occasions, no response or acknowledgement will be given.
+* It indicates that the state of one or more of the endpoint properties retrieved from the openHAB server are considered invalid, mostly because it is in either uninitialized `NULL` or undefined `UNDEF` state.
+* To resolve this error, make sure that all items interfacing with Alexa have a defined state.
+* For group endpoints, partial properties responses will be send back to Alexa excluding items with invalid state. This will allow Alexa to acknowledge a command request assuming that the relevant item state is accurate. However, it will cause Alexa to generate this error when requesting the status of a device configured with an interface supporting that feature. For example, using a thermostat group endpoint, a request to set its mode will succeed but requesting its mode status will fail if one of its property state, such as its temperature sensor, is not defined in openHAB.
+* This is the default error.
+
+#### Server Authentication Issue
+* Alexa will respond with "Sorry something wrong, to control _device_ try disabling the skill and re-enabling it from your Alexa app"
+* It indicates that Alexa isn't able to control the given device because of an authentication issue.
+* To resolve this error, for users that are using the official skill, just disable and re-enable it through the Alexa app. For users that have setup their own custom skill, make sure that the proper credentials were added to the lambda function config.js.
+
+#### Server Not Accessible
+* Alexa will respond with "Sorry the hub that _device_ is connected to is not responding, please check its network connection and power supply"
+* It indicates that your openHAB server is not accessible through [myopenHAB](https://myopenhab.org) cloud service.
+* To resolve this error, make sure that your server is running and showing online under your myopenHAB account. For users that have setup their own custom skill, make sure that the proper server base url was added to the lambda function config.js.
+
 ## Setup
 
 * NEW Alexa Version 3 API syntax (v3)
   * Version 3 of the Alex Skill API introduces a more rich and complex set of features that required a change in how items are configured by using the new metadata feature introduced in openaHAB 2.3
   * Version 2 tags are still supported and are converted internally to V3 meta data
   * See [Label Support](#Label-Support) for using labels in item tags and meta data.
+  * Supported [item](#supported-item-metadata) & [group](#supported-group-metadata) V3 meta data
+  * Automatically determine number precision and unit based on [item state presentation](#item-state) and [unit of measurement](#item-unit-of-measurement).
+  * Decoupling between item receiving command and item state via an [item sensor](#item-sensor)
+  * Improved Alexa response state accuracy
 
 ### Item Label Recommendation
 
@@ -44,10 +79,6 @@ Matching of voice commands to Items happens based on the Item label (e.g. "Kitch
 ### Item Configuration
 
 The Alexa skill API uses the concept of "endpoints".  Endpoints are addressable entities that expose functionality in the form of capability interfaces.  An example endpoint may be a light switch, which has a single capability called power state (ON/OFF).  A more complex endpoint may be a thermostat which has many capabilities to control and report temperature, setpoints, modes, etc..
-
-### Item State
-
-Item states, reported back to Alexa, are formatted based on their [item state presentation](https://www.openhab.org/docs/configuration/items.html#state-presentation) definition if configured. This means you can control the precision of number values (e.g. `%.1f °C` will limit reported temperature value to one decimal point).
 
 #### Single items
 Single items in openHAB can be mapped to single endpoint in Alex through the use of the Alexa metadata.
@@ -80,64 +111,82 @@ For this example we will use various use cases, a thermostat, a stereo, a securi
 In openHAB a thermostat is modeled as many different items, typically there are items for set points (target, heat, cool), modes, and the current temperature. To map these items to a single endpoint in Alexa, we will add them to a group which also uses "Alexa" metadata. When items are alexa-enabled, but are also a member of a group alexa-enabled, they will be added to the group endpoint and not exposed as their own endpoints.
 
 ```
-  Group  Thermostat    "Bedroom"                                {alexa="Endpoint.Thermostat"}
-  Number Temperature   "Temperature [%.0f F]"    (Thermostat)   {alexa="TemperatureSensor.temperature"}
-  Number HeatSetpoint  "Heat Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.upperSetpoint"}
-  Number CoolSetpoint  "Cool Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.lowerSetpoint"}
-  Number Mode          "Mode [%s]"               (Thermostat)   {alexa="ThermostatController.thermostatMode"}
-  ```
+Group  Thermostat    "Bedroom"                                {alexa="Endpoint.Thermostat"}
+Number Temperature   "Temperature [%.0f F]"    (Thermostat)   {alexa="TemperatureSensor.temperature"}
+Number HeatSetpoint  "Heat Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.upperSetpoint"}
+Number CoolSetpoint  "Cool Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.lowerSetpoint"}
+Number Mode          "Mode [%s]"               (Thermostat)   {alexa="ThermostatController.thermostatMode"}
+```
 
-  The group metadata also describes the category for the endpoint, in this case a "Thermostat".  See the section below on Group mapping metadata and categories for a complete list.  In this example a single endpoint is created called "Bedroom", its various interfaces are mapped to different openHAB items.  You can ask Alexa "Set the Bedroom heat to 72" and the 'HeatSetpoint' will receive the command, likewise you can ask Alexa "What's the temperature of the Bedroom" and Alexa will query the 'Temperature' items for its value.
+The group metadata also describes the category for the endpoint, in this case a "Thermostat".  See the section below on Group mapping metadata and categories for a complete list.  In this example a single endpoint is created called "Bedroom", its various interfaces are mapped to different openHAB items.  You can ask Alexa "Set the Bedroom heat to 72" and the 'HeatSetpoint' will receive the command, likewise you can ask Alexa "What's the temperature of the Bedroom" and Alexa will query the 'Temperature' items for its value.
 
-  When mapping items, sometime we need to pass additional parameters to Alexa to set things like what scale to use (Fahrenheit) or what values our items expect for certain states (thermostat modes). These parameters can be passed in the metadata properties, if they are omitted, then reasonable defaults are used.  In our above example we may wish to use Fahrenheit as our temperature scale, and map the mode strings to numbers.  This would look like:
+When mapping items, sometime we need to pass additional parameters to Alexa to set things like what scale to use (Fahrenheit) or what values our items expect for certain states (thermostat modes). These parameters can be passed in the metadata properties, if they are omitted, then reasonable defaults are used.  In our above example we may wish to use Fahrenheit as our temperature scale, and map the mode strings to numbers.  This would look like:
 
 ```
-  Group  Thermostat    "Thermostat"                             {alexa="Endpoint.Thermostat"}
-  Number Temperature   "Temperature [%.0f F]"    (Thermostat)   {alexa="TemperatureSensor.temperature" [scale="Fahrenheit"]}
-  Number HeatSetpoint  "Heat Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.upperSetpoint" [scale="Fahrenheit"]}
-  Number CoolSetpoint  "Cool Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.lowerSetpoint" [scale="Fahrenheit"]}
-  Number Mode          "Mode [%s]"               (Thermostat)   {alexa="ThermostatController.thermostatMode" [OFF=0,HEAT=1,COOL=2,AUTO=3]}
-  ```
+Group  Thermostat    "Thermostat"                             {alexa="Endpoint.Thermostat"}
+Number Temperature   "Temperature [%.0f F]"    (Thermostat)   {alexa="TemperatureSensor.temperature" [scale="Fahrenheit"]}
+Number HeatSetpoint  "Heat Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.upperSetpoint" [scale="Fahrenheit"]}
+Number CoolSetpoint  "Cool Setpoint [%.0f F]"  (Thermostat)   {alexa="ThermostatController.lowerSetpoint" [scale="Fahrenheit"]}
+Number Mode          "Mode [%s]"               (Thermostat)   {alexa="ThermostatController.thermostatMode" [OFF=0,HEAT=1,COOL=2,AUTO=3]}
+```
 
-  A Stereo is another example of a single endpoint that needs many items to function properly.  Power, volume, input, speakers and player controllers are all typical use cases for a stereo that a user may wish to control.
+A Stereo is another example of a single endpoint that needs many items to function properly.  Power, volume, input, speakers and player controllers are all typical use cases for a stereo that a user may wish to control.
 
 ```
-  Group Stereo    "Stereo"            {alexa="Endpoint.Speaker"}
-  Number Volume   "Volume"  (Stereo)  {alexa="Speaker.volume"}
-  Switch Mute     "Mute"    (Stereo)  {alexa="Speaker.muted"}
-  Switch Power    "Power"   (Stereo)  {alexa="PowerController.powerState"}
-  String Input    "Input"   (Stereo)  {alexa="InputController.input" [supportedInputs="HDMI1,TV"]}
-  String Channel  "Channel" (Stereo)  {alexa="ChannelController.channel"}
-  Player Player   "Player"  (Stereo)  {alexa="PlaybackController.playbackState"}
-  ```
+Group Stereo    "Stereo"            {alexa="Endpoint.Speaker"}
+Number Volume   "Volume"  (Stereo)  {alexa="Speaker.volume"}
+Switch Mute     "Mute"    (Stereo)  {alexa="Speaker.muted"}
+Switch Power    "Power"   (Stereo)  {alexa="PowerController.powerState"}
+String Input    "Input"   (Stereo)  {alexa="InputController.input" [supportedInputs="HDMI1,TV"]}
+String Channel  "Channel" (Stereo)  {alexa="ChannelController.channel"}
+Player Player   "Player"  (Stereo)  {alexa="PlaybackController.playbackState"}
+```
 
-  A security system is another example including alarm mode and different alarm states.
+A security system is another example including alarm mode and different alarm states.
 
 ```
-  Group  SecuritySystem      "Security System"                  {alexa="Endpoint.SecurityPanel"}
-  String AlarmMode           "Alarm Mode"      (SecuritySystem) {alexa="SecurityPanelController.armState" [supportedArmStates="DISARMED,ARMED_STAY,ARMED_AWAY"]}
-  Switch BurglaryAlarm       "Burglary"        (SecuritySystem) {alexa="SecurityPanelController.burglaryAlarm"}
-  Switch FireAlarm           "Fire"            (SecuritySystem) {alexa="SecurityPanelController.fireAlarm"}
-  Switch CarbonMonoxideAlarm "Carbon Monoxide" (SecuritySystem) {alexa="SecurityPanelController.carbonMonoxideAlarm"}
-  Switch WaterAlarm          "Water"           (SecuritySystem) {alexa="SecurityPanelController.waterAlarm"}
-  ```
+Group  SecuritySystem      "Security System"                  {alexa="Endpoint.SecurityPanel"}
+String AlarmMode           "Alarm Mode"      (SecuritySystem) {alexa="SecurityPanelController.armState" [supportedArmStates="DISARMED,ARMED_STAY,ARMED_AWAY"]}
+Switch BurglaryAlarm       "Burglary"        (SecuritySystem) {alexa="SecurityPanelController.burglaryAlarm"}
+Switch FireAlarm           "Fire"            (SecuritySystem) {alexa="SecurityPanelController.fireAlarm"}
+Switch CarbonMonoxideAlarm "Carbon Monoxide" (SecuritySystem) {alexa="SecurityPanelController.carbonMonoxideAlarm"}
+Switch WaterAlarm          "Water"           (SecuritySystem) {alexa="SecurityPanelController.waterAlarm"}
+```
 
-  For components of a device, which isn't covered by the existing interfaces, that have more than one setting, characterized by a number within a range or just turn on and off, the Mode, Range and Toggle controllers can be used to highly customize how you interact with that device via Alexa. Below are few examples on how these interfaces can be used. Details about to the configuration settings are listed in the next section under the relevant interface.
+For components of a device, which isn't covered by the existing interfaces, that have more than one setting, characterized by a number within a range or just turn on and off, the Mode, Range and Toggle controllers can be used to highly customize how you interact with that device via Alexa. Below are few examples on how these interfaces can be used. Details about to the configuration settings are listed in the next section under the relevant interface.
 
 ```
-  Group Washer       "Washer"               {alexa="Endpoint.Other"}
-  String Cycle       "Cycle"       (Washer) {alexa="ModeController.mode" [supportedModes="Normal=Normal:Cottons,Delicate=@Value.Delicate:Knites",friendlyNames="Wash Cycle,Wash Setting",ordered=false]}
-  Number Temperature "Temperature" (Washer) {alexa="ModeController.mode" [supportedModes="0=Cold:Cool,1=Warm,2=Hot",friendlyNames="Wash Temperature,@Setting.WaterTemperature",ordered=true]}  
-  Switch Power       "Power"       (Washer) {alexa="ToggleController.toggleState" [friendlyNames="DeviceName.Washer"]}
-  ```
+Group Washer       "Washer"               {alexa="Endpoint.Other"}
+String Cycle       "Cycle"       (Washer) {alexa="ModeController.mode" [supportedModes="Normal=Normal:Cottons,Delicate=@Value.Delicate:Knites",friendlyNames="Wash Cycle,Wash Setting",ordered=false]}
+Number Temperature "Temperature" (Washer) {alexa="ModeController.mode" [supportedModes="0=Cold:Cool,1=Warm,2=Hot",friendlyNames="Wash Temperature,@Setting.WaterTemperature",ordered=true]}  
+Switch Power       "Power"       (Washer) {alexa="ToggleController.toggleState" [friendlyNames="DeviceName.Washer"]}
 ```
-  Group Fan     "Fan"          {alexa="Endpoint.Other"}
-  Number Speed  "Speed"  (Fan) {alexa="RangeController.rangeValue" [supportedRange="1:10:1",presets="1=@Value.Minimum:@Value.Low:Lowest,10=@Value.Maximum:@Value.High:Highest",friendlyNames="@Setting.FanSpeed,Speed"]}
-  Switch Rotate "Rotate" (Fan) {alexa="ToggleController.toggleState" [friendlyNames="@Setting.Oscillate,Rotate"]}
-  Switch Power  "Power"  (Fan) {alexa="ToggleController.toggleState" [friendlyNames="@DeviceName.Fan"]}
-  ```
+```
+Group Fan     "Fan"          {alexa="Endpoint.Other"}
+Number Speed  "Speed"  (Fan) {alexa="RangeController.rangeValue" [supportedRange="1:10:1",presets="1=@Value.Minimum:@Value.Low:Lowest,10=@Value.Maximum:@Value.High:Highest",friendlyNames="@Setting.FanSpeed,Speed"]}
+Switch Rotate "Rotate" (Fan) {alexa="ToggleController.toggleState" [friendlyNames="@Setting.Oscillate,Rotate"]}
+Switch Power  "Power"  (Fan) {alexa="ToggleController.toggleState" [friendlyNames="@DeviceName.Fan"]}
+```
 
-#### Supported item mapping metadata
+#### Item Sensor
+* When available, use a specific item (called "sensor") for property state reporting over the actionable item state.
+* Design to bridge channel status items to provide improved reporting state accuracy.
+* Configured by adding the `itemSensor=<itemName>` metadata parameter.
+* Sensor items need to be the same type than their parent item, except for LockController capable items.
+
+#### Item State
+* Item states, reported back to Alexa, are formatted based on their [item state presentation](https://www.openhab.org/docs/configuration/items.html#state-presentation) definition if configured. This means you can control the precision of number values (e.g. `%.1f °C` will limit reported temperature value to one decimal point).
+
+#### Item Unit of Measurement
+* With the introduction of the [unit of measurement](https://www.openhab.org/docs/concepts/units-of-measurement.html) concept, the item unit can be automatically determined for thermostat and temperature using that feature, removing the need of having to set the metadata scale parameter for each of the relevant items or groups.
+* Below are two examples; the scale on the first will be set to Fahrenheit based on how it is defined in the item state presentation pattern and the second one will be set based on your openHAB system regional settings (US=Fahrenheit; SI=Celsius).
+
+```
+Number:Temperature Temperature1 "Temperature [%.1f °F]" {alexa="TemperatureSensor.temperature"}
+Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSensor.temperature"}
+```
+
+#### Supported Item Metadata
 * The following are a list of supported metadata.
   * `PowerController.powerState`
     * Items that turn on or off such as light switches, power states, etc..
@@ -391,7 +440,7 @@ In openHAB a thermostat is modeled as many different items, typically there are 
       * Switch
     * Default category: SECURITY_PANEL
   * `ModeController.mode`
-    * Items that represent components of a device that have more than one setting. Multiple instances can be configured in a group endpoint. By default, to ask for a specific mode, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#item-friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#item-asset-catalog) can be used to label a mode as well prefixing with an @ sign (e.g. `friendlyNames=Wash Temperature,@Setting.WaterTemperature`). In regards to supported modes and their mappings, by default if omitted, the openHAB item state description options, if defined, are used to determine these configurations. To configure it, use `supportedModes` parameter and provide a comma delimited list of mode mappings composed of openHAB item states and the associated names/asset ids they should be called, delimited by equal and column signs (e.g. `supportedModes="0=Cold:Cool,1=Warm,2=Hot"`). For string based modes if the mapping state value and name are the same (case sensitive), a shortened format can be used, where the name doesn't need to be added to the list by either leaving the first element empty or not providing the names at all (e.g. `supportedModes="Normal=:Cottons,Whites"` <=> `supportedModes="Normal=Normal:Cottons,Whites=Whites`). Additionally, if the mode can be adjusted incrementally (e.g. temperature control), set parameter `ordered=true`, otherwise only requests to set a specific mode will be accepted.
+    * Items that represent components of a device that have more than one setting. Multiple instances can be configured in a group endpoint. By default, to ask for a specific mode, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#asset-catalog) can be used to label a mode as well prefixing with an @ sign (e.g. `friendlyNames=Wash Temperature,@Setting.WaterTemperature`). In regards to supported modes and their mappings, by default if omitted, the openHAB item state description options, if defined, are used to determine these configurations. To configure it, use `supportedModes` parameter and provide a comma delimited list of mode mappings composed of openHAB item states and the associated names/asset ids they should be called, delimited by equal and column signs (e.g. `supportedModes="0=Cold:Cool,1=Warm,2=Hot"`). For string based modes if the mapping state value and name are the same (case sensitive), a shortened format can be used, where the name doesn't need to be added to the list by either leaving the first element empty or not providing the names at all (e.g. `supportedModes="Normal=:Cottons,Whites"` <=> `supportedModes="Normal=Normal:Cottons,Whites=Whites`). Additionally, if the mode can be adjusted incrementally (e.g. temperature control), set parameter `ordered=true`, otherwise only requests to set a specific mode will be accepted.
     * Supported item type:
       * Number
       * String
@@ -406,7 +455,7 @@ In openHAB a thermostat is modeled as many different items, typically there are 
       * ordered=`<boolean>`
         * defaults to false
   * `RangeController.rangeValue`
-    * Items that represent components of a device that are characterized by numbers within a minimum and maximum range. Multiple instances can be configured in a group endpoint. By default, to ask for a specific range, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#item-friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#item-asset-catalog) can be used to label a mode as well  prefixing with an @ sign (e.g. `friendlyNames="@Setting.FanSpeed,Speed"`). To set the supported range, provide a column delimited list including minimum, maximum and precision values. The latter value will be use as default increment when requesting adjusted range values. Optionally, to name specific presets, like fan speeds low [1] & high value [10], can be added in `presets` parameter and provide a comma delimited list of preset mappings composed of range value and the associated names/asset ids they should be called, delimited by equal and column signs (e.g. `presets="1=@Value.Minimum:@Value.Low:Lowest,10=@Value.Maximum:@Value.High:Highest"`). Another optional settings is `unitOfMeasure` parameter which gives a unit of measure to the range values. By default if omitted, it is based on the unit of measurement number item type that have a supported unit, otherwise, a [unit id](#item-unit-of-measurement-catalog) can be used. (e.g. `unitOfMeasure=Angle.Degrees`)
+    * Items that represent components of a device that are characterized by numbers within a minimum and maximum range. Multiple instances can be configured in a group endpoint. By default, to ask for a specific range, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#asset-catalog) can be used to label a mode as well  prefixing with an @ sign (e.g. `friendlyNames="@Setting.FanSpeed,Speed"`). To set the supported range, provide a column delimited list including minimum, maximum and precision values. The latter value will be use as default increment when requesting adjusted range values. Optionally, to name specific presets, like fan speeds low [1] & high value [10], can be added in `presets` parameter and provide a comma delimited list of preset mappings composed of range value and the associated names/asset ids they should be called, delimited by equal and column signs (e.g. `presets="1=@Value.Minimum:@Value.Low:Lowest,10=@Value.Maximum:@Value.High:Highest"`). Another optional settings is `unitOfMeasure` parameter which gives a unit of measure to the range values. By default if omitted, it is based on the unit of measurement number item type that have a supported unit, otherwise, a [unit id](#unit-of-measurement-catalog) can be used. (e.g. `unitOfMeasure=Angle.Degrees`)
     * Supported item type:
       * Dimmer
       * Number
@@ -429,7 +478,7 @@ In openHAB a thermostat is modeled as many different items, typically there are 
       * unitOfMeasure=`<unitId>` (optional)
         * defaults to item state unit of measurement symbol for Number:* item types
   * `ToggleController.toggleState`
-    * Items that represent components of a device that can be turned on or off. Multiple instances can be configured in a group endpoint. By default, to ask for a specific range, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#item-friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#item-asset-catalog) can be used to label a mode as well with an @ sign prefix (e.g. `friendlyNames="@Setting.Oscillate,Rotate"`).
+    * Items that represent components of a device that can be turned on or off. Multiple instances can be configured in a group endpoint. By default, to ask for a specific range, the item label will be used as the friendly name. To configure it, use `friendlyNames` parameter and provide a comma delimited list of different labels (Keep in mind that some names are [not allowed](#friendly-names-not-allowed)). Additionally, pre-defined [asset ids](#asset-catalog) can be used to label a mode as well with an @ sign prefix (e.g. `friendlyNames="@Setting.Oscillate,Rotate"`).
     * Supported item type:
       * Color
       * Dimmer
@@ -440,19 +489,6 @@ In openHAB a thermostat is modeled as many different items, typically there are 
       * friendlyNames=`<names>`
         * each name formatted as `<@assetIdOrName>`
         * defaults to item label name
-
-##### Item Scale
-  * With the introduction of the [unit of measurement](https://www.openhab.org/docs/concepts/units-of-measurement.html) concept, the item scale can be automatically determined for thermostat and temperature using that feature, removing the need of having to set a metadata scale parameter for each of the relevant items or groups.
-  * Below are two examples; the scale on the first will be set to Fahrenheit based on how it is defined in the item state presentation pattern and the second one will be set based on your openHAB system regional settings (US=Fahrenheit; SI=Celsius).
-
-  `Number:Temperature Temperature1 "Temperature [%.1f °F]" {alexa="TemperatureSensor.temperature"}`
-  `Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSensor.temperature"}`
-
-##### Item Sensor
-  * When available, use a specific item (called "sensor") for property state reporting over the actionable item state.
-  * Design to bridge channel status items to provide improved reporting state accuracy.
-  * Configured by adding the `itemSensor=<itemName>` metadata parameter.
-  * Sensor items need to be the same type than their parent item, except for LockController capable items.
 
 ##### Item Categories
   * Alexa has certain categories that effect how voice control and their mobile/web UI's display or control endpoints.  An example of this is when you create "Smart Device Groups" in the Alex app and associate a specific Echo or Dot to that Group (typically a room).  When a user asks to turn the lights ON, Alexa looks for devices in that group that have the category "LIGHT" to send the command to.  
@@ -482,7 +518,7 @@ TEMPERATURE_SENSOR | Indicates endpoints that report the temperature only.
 THERMOSTAT | Indicates endpoints that control temperature, stand-alone air conditioners, or heaters with direct temperature control.  
 TV | Indicates the endpoint is a television.  
 
-##### Item Asset Catalog
+##### Asset Catalog
   * List of Alexa asset catalog from [Alexa Skill API](https://developer.amazon.com/docs/device-apis/resources-and-assets.html#global-alexa-catalog) docs:
 
 Asset Identifier | Supported Friendly Names
@@ -517,8 +553,8 @@ Value.High | High
 Value.Low | Low
 Value.Medium | Medium<br>Mid
 
-##### Item Friendly Names Not Allowed
-  * List of Alexa friendly names that cannot be used from [Alexa Skill API](https://developer.amazon.com/docs/device-apis/resources-and-assets.html#names-you-cannot-use)
+##### Friendly Names Not Allowed
+  * List of Alexa friendly names that cannot be used from [Alexa Skill API](https://developer.amazon.com/docs/device-apis/resources-and-assets.html#names-you-cannot-use) docs:
 
 Friendly Names |
 ---------------|
@@ -545,7 +581,7 @@ treble |
 volume |
 way f. m. |
 
-##### Item Unit of Measurement Catalog
+##### Unit of Measurement Catalog
   * List of Alexa unit of measurement catalog from [Alexa Skill API](https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html#supported-values-for-unitofmeasure) docs:
 
 Unit Identifier |
@@ -574,14 +610,14 @@ Volume.CubicFeet |
 Weight.Pounds |
 Weight.Ounces |
 
-#### Supported Group mapping metadata
+#### Supported Group Metadata
 * Functional groups (no group type) can be labelled with one of Alexa categories listed above. It can be set using one of the two formats: `Endpoint.<category>` or `<category>`
 * Example `{alexa="Endpoint.Thermostat"}` or `{alexa="Thermostat"}`
 * Child item categories are ignored and only the group category is used on items.
 * Case is ignored on the category part of the metadata and any value will be made all uppercase before its passed to the Alexa API.
 
 #### Label Support
-Item tags and metadata labels translate to a set of capabilities and can be usesd as a convenience to using the longer meta data format configuration.  These are the same as v2 tags but add additional functions and provide the ability to add customization through additional properties which take precedence over the default ones. Here are some examples:
+Item tags and metadata labels translate to a set of capabilities and can be used as a convenience to using the longer meta data format configuration.  These are the same as v2 tags but add additional functions and provide the ability to add customization through additional properties which take precedence over the default ones. Here are some examples:
 ```
 Switch OutletPlug "Outlet Plug" {alexa="Switchable" [category="SMARTPLUG"]}
 Switch TelevisionPower "Television Power" {alexa="Switchable" [category="TV"]}
@@ -798,7 +834,7 @@ Number RangeComponent "Range Component" {alexa="RangeController.rangeValue"}
 ```
 * ToggleComponent
 ```
-Switch ToggleComponent "Toggle Component" ["Toggle Component"]
+Switch ToggleComponent "Toggle Component" ["ToggleComponent"]
 
 Switch ToggleComponent "Toggle Component" {alexa="ToggleComponent"}
 

--- a/alexa/capabilities.js
+++ b/alexa/capabilities.js
@@ -80,6 +80,7 @@ function getCapabilityInterface(interfaceName, properties, settings = {}) {
   const locale = settings.regional && settings.regional.language && settings.regional.region ?
     [settings.regional.language, settings.regional.region].join('-') : 'en-US';
 
+  // Initialize capability common properties
   const configuration = {};
   const resources = {};
   const supported = [];
@@ -105,6 +106,18 @@ function getCapabilityInterface(interfaceName, properties, settings = {}) {
           'supportsScheduling': false
         }, parameters.supportedModes && {
           'supportedModes': parameters.supportedModes
+        });
+        break;
+      case 'armState':
+        Object.assign(configuration, {
+          'supportsArmInstant': parameters.supportsArmInstant === true,
+          'supportedArmStates': parameters.supportedArmStates.reduce((states, state) => states.concat({
+            'value': state
+          }), [])
+        }, parameters.supportsPinCodes === true && {
+          'supportedAuthorizationTypes': [{
+            'type': 'FOUR_DIGIT_PIN'
+          }]
         });
         break;
       case 'mode':
@@ -239,7 +252,7 @@ function getPropertySettings(capability) {
   const properties = CAPABILITIES[interfaceName] && CAPABILITIES[interfaceName]['properties'] || [];
   const property = properties.find(property => property.name === propertyName) || {};
 
-  return Object.assign(property, PROPERTY_SCHEMAS[property.schema]);
+  return Object.assign({}, property, PROPERTY_SCHEMAS[property.schema]);
 }
 
 /**

--- a/alexa/config.js
+++ b/alexa/config.js
@@ -135,6 +135,16 @@ module.exports = Object.freeze({
         {'name': 'scene', 'schema': 'scene', 'isReportable': false}
       ]
     },
+    'SecurityPanelController': {
+      'category': 'SECURITY_PANEL',
+      'properties': [
+        {'name': 'armState', 'schema': 'armState'},
+        {'name': 'burglaryAlarm', 'schema': 'alarmState'},
+        {'name': 'fireAlarm', 'schema': 'alarmState'},
+        {'name': 'carbonMonoxideAlarm', 'schema': 'alarmState'},
+        {'name': 'waterAlarm', 'schema': 'alarmState'}
+      ]
+    },
     'Speaker': {
       'category': 'SPEAKER',
       'properties': [
@@ -203,6 +213,42 @@ module.exports = Object.freeze({
    * @type {Object}
    */
   PROPERTY_SCHEMAS: {
+    'alarmState': {
+      'itemTypes': ['Contact', 'Switch'],
+      'state': {
+        'map': {
+          'default': {
+            'Contact': {'OK': 'CLOSED', 'ALARM': 'OPEN'},
+            'Switch':  {'OK': 'OFF', 'ALARM': 'ON'}
+          }
+        },
+        'type': 'string'
+      }
+    },
+    'armState': {
+      'itemTypes': ['Number', 'String', 'Switch'],
+      'state': {
+        'map': {
+          'default': {
+            'Number': {
+              'DISARMED': '0', 'ARMED_STAY': '1', 'ARMED_AWAY': '2', 'ARMED_NIGHT': '3', 'AUTHORIZATION_REQUIRED': '4',
+              'NOT_READY': '5', 'UNCLEARED_ALARM': '6', 'UNCLEARED_TROUBLE': '7', 'BYPASS_NEEDED': '8'
+            },
+            'String': {
+              'DISARMED': 'disarm', 'ARMED_STAY': 'stay', 'ARMED_AWAY': 'away', 'ARMED_NIGHT': 'night',
+              'AUTHORIZATION_REQUIRED': 'authreq', 'UNAUTHORIZED': 'unauth', 'NOT_READY': 'notrdy',
+              'UNCLEARED_ALARM': 'alarm', 'UNCLEARED_TROUBLE': 'trouble', 'BYPASS_NEEDED': 'bypass'
+            },
+            'Switch': {'DISARMED': 'OFF', 'ARMED_STAY': 'ON'}
+          }
+        },
+        'supported': [
+          // https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html#configuration
+          'ARMED_AWAY', 'ARMED_STAY', 'ARMED_NIGHT', 'DISARMED'
+        ],
+        'type': 'string'
+      }
+    },
     'brightness': {
       'itemTypes': ['Color', 'Dimmer'],
       'state': {
@@ -247,6 +293,17 @@ module.exports = Object.freeze({
     'inputs': {
       'itemTypes': ['String'],
       'state': {
+        'supported': [
+          // https://developer.amazon.com/docs/device-apis/alexa-property-schemas.html#input-values
+          'AUX 1', 'AUX 2', 'AUX 3', 'AUX 4', 'AUX 5', 'AUX 6', 'AUX 7', 'BLURAY', 'CABLE', 'CD',
+          'COAX 1', 'COAX 2', 'COMPOSITE 1', 'DVD', 'GAME', 'HD RADIO', 'HDMI 1', 'HDMI 2', 'HDMI 3',
+          'HDMI 4', 'HDMI 5', 'HDMI 6', 'HDMI 7', 'HDMI 8', 'HDMI 9', 'HDMI 10', 'HDMI ARC', 'INPUT 1',
+          'INPUT 2', 'INPUT 3', 'INPUT 4', 'INPUT 5', 'INPUT 6', 'INPUT 7', 'INPUT 8', 'INPUT 9',
+          'INPUT 10', 'IPOD', 'LINE 1', 'LINE 2', 'LINE 3', 'LINE 4', 'LINE 5', 'LINE 6', 'LINE 7',
+          'MEDIA PLAYER', 'OPTICAL 1', 'OPTICAL 2', 'PHONO', 'PLAYSTATION', 'PLAYSTATION 3',
+          'PLAYSTATION 4', 'SATELLITE', 'SMARTCAST', 'TUNER', 'TV', 'USB DAC', 'VIDEO 1', 'VIDEO 2',
+          'VIDEO 3', 'XBOX'
+        ],
         'type': 'string'
       }
     },
@@ -344,6 +401,10 @@ module.exports = Object.freeze({
             'Switch': {'HEAT': 'ON', 'OFF': 'OFF'}
           }
         },
+        'supported': [
+          // https://developer.amazon.com/docs/device-apis/alexa-property-schemas.html#thermostat-mode-values
+          'AUTO', 'COOL', 'HEAT', 'ECO', 'OFF'
+        ],
         'type': 'string'
       }
     },
@@ -393,34 +454,6 @@ module.exports = Object.freeze({
     'ACTIVITY_TRIGGER', 'CAMERA', 'CONTACT_SENSOR', 'DOOR', 'DOORBELL', 'LIGHT', 'MICROWAVE',
     'MOTION_SENSOR', 'OTHER', 'SCENE_TRIGGER', 'SECURITY_PANEL', 'SMARTLOCK', 'SMARTPLUG',
     'SPEAKER', 'SWITCH', 'TEMPERATURE_SENSOR', 'THERMOSTAT', 'TV'
-  ],
-
-
-  /**
-   * Defines alexa supported input controller names
-   *  https://developer.amazon.com/docs/device-apis/alexa-property-schemas.html#input-values
-   *
-   * @type {Array}
-   */
-  INPUT_NAMES: [
-    'AUX 1', 'AUX 2', 'AUX 3', 'AUX 4', 'AUX 5', 'AUX 6', 'AUX 7', 'BLURAY', 'CABLE', 'CD',
-    'COAX 1', 'COAX 2', 'COMPOSITE 1', 'DVD', 'GAME', 'HD RADIO', 'HDMI 1', 'HDMI 2', 'HDMI 3',
-    'HDMI 4', 'HDMI 5', 'HDMI 6', 'HDMI 7', 'HDMI 8', 'HDMI 9', 'HDMI 10', 'HDMI ARC', 'INPUT 1',
-    'INPUT 2', 'INPUT 3', 'INPUT 4', 'INPUT 5', 'INPUT 6', 'INPUT 7', 'INPUT 8', 'INPUT 9',
-    'INPUT 10', 'IPOD', 'LINE 1', 'LINE 2', 'LINE 3', 'LINE 4', 'LINE 5', 'LINE 6', 'LINE 7',
-    'MEDIA PLAYER', 'OPTICAL 1', 'OPTICAL 2', 'PHONO', 'PLAYSTATION', 'PLAYSTATION 3',
-    'PLAYSTATION 4', 'SATELLITE', 'SMARTCAST', 'TUNER', 'TV', 'USB DAC', 'VIDEO 1', 'VIDEO 2',
-    'VIDEO 3', 'XBOX'
-  ],
-
-  /**
-   * Defines alexa supported thermostat modes
-   *  https://developer.amazon.com/docs/device-apis/alexa-property-schemas.html#thermostat-mode-values
-   *
-   * @type {Array}
-   */
-  THERMOSTAT_MODES: [
-    'AUTO', 'COOL', 'HEAT', 'ECO', 'OFF'
   ],
 
   /**

--- a/alexa/directive.js
+++ b/alexa/directive.js
@@ -85,16 +85,7 @@ class AlexaDirective extends AlexaResponse {
       }
     }).catch((error) => {
       log.error('postItemsAndReturn failed with error:', error);
-      if (error.statusCode === 404) {
-        this.returnAlexaErrorResponse({
-          payload: {
-            type: 'NO_SUCH_ENDPOINT',
-            message: 'Endpoint not found'
-          }
-        });
-      } else {
-        this.returnAlexaGenericErrorResponse();
-      }
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 
@@ -109,7 +100,7 @@ class AlexaDirective extends AlexaResponse {
     // Use the property map defined interface names if this.interface not defined (e.g. reportState)
     const interfaceNames = this.interface ? [this.interface] : Object.keys(this.propertyMap);
     // Get list of all unique item objects part of interfaces
-    const interfaceItems = this.propertyMap.getItemsByInterfaces(interfaceNames);
+    const interfaceItems = this.propertyMap.getItemsByInterfaces(interfaceNames, parameters.properties);
     // Define get item state promises array, excluding items with defined state already
     const promises = interfaceItems.reduce((promises, item) => promises.concat(
       typeof item.state !== 'undefined' ? [] : this.getItemState(item).then((result) => {
@@ -121,16 +112,15 @@ class AlexaDirective extends AlexaResponse {
       })
     ), []);
     Promise.all(promises).then((items) => {
-      // Throw error if one of the state item is set to 'NULL'
-      if (items.find(item => item.state === 'NULL')) {
-        throw {reason: 'Invalid item state returned by openHAB', items: items};
+      // Define endpoint health status based on every retrieved item states being defined
+      const isEndpointHealthy = items.every(item => typeof item.state !== 'undefined');
+      // Get context properties response
+      const properties = this.propertyMap.getContextPropertiesResponse(interfaceNames, isEndpointHealthy);
+      // Throw error if no context properties found
+      if (properties.length === 0) {
+        throw {cause: 'Unable to get context properties response', properties: this.propertyMap};
       }
-      // Get context properties response and throw error if one of its value not defined
-      const properties = this.propertyMap.getContextPropertiesResponse(interfaceNames, parameters.properties);
-      if (properties.find(property => typeof property.value === 'undefined')) {
-        throw {reason: 'Undefined context property value', properties: properties};
-      }
-      // Get error response based on property name/value if method defined
+      // Get error response based on context property name/value if method defined
       const error = properties.reduce((error, property) => {
         const method = property.name + 'ErrorResponse';
         return this[method] && this[method](property.value) || error;
@@ -149,16 +139,7 @@ class AlexaDirective extends AlexaResponse {
       }
     }).catch((error) => {
       log.error('getPropertiesResponseAndReturn failed with error:', error);
-      if (error.statusCode === 404) {
-        this.returnAlexaErrorResponse({
-          payload: {
-            type: 'NO_SUCH_ENDPOINT',
-            message: 'Endpoint not found'
-          }
-        });
-      } else {
-        this.returnAlexaGenericErrorResponse();
-      }
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 
@@ -170,7 +151,8 @@ class AlexaDirective extends AlexaResponse {
   getItemState(item) {
     const itemName = item.sensor || item.name;
     return rest.getItem(this.directive.endpoint.scope.token, itemName).then((result) =>
-      Object.assign(result, {state: formatItemState(result)}));
+      // Set state to undefined if uninitialized or undefined in oh, otherwise get formatted item state
+      Object.assign(result, {state: ['NULL', 'UNDEF'].includes(result.state) ? undefined : formatItemState(result)}));
   }
 }
 
@@ -192,7 +174,7 @@ function formatItemState(item) {
   const state = item.state;
   const type = item.type.split(':').shift();
 
-  if (format && state != 'NULL') {
+  if (format) {
     switch (type) {
       case 'Dimmer':
       case 'Number':

--- a/alexa/propertyState.js
+++ b/alexa/propertyState.js
@@ -11,7 +11,7 @@
  * Amazon Smart Home Skill Property State for API V3
  */
 const { getPropertyStateMap } = require('./capabilities.js');
-const { INPUT_NAMES } = require('./config.js');
+const { PROPERTY_SCHEMAS } = require('./config.js');
 
 /**
  * Defines normalize functions
@@ -105,7 +105,7 @@ const normalizeFunctions = {
   inputs: function (value) {
     const input = value.replace(/(\S)(\d+)$/, '$1 $2').toUpperCase();
 
-    if (INPUT_NAMES.includes(input)) {
+    if (PROPERTY_SCHEMAS.inputs.state.supported.includes(input)) {
       return input;
     }
   },
@@ -203,7 +203,8 @@ const normalizeFunctions = {
 function normalize(property, value, options) {
   const propertyStateMap = getPropertyStateMap(property);
   const method = property.schema.name;
-  let state = typeof value !== 'undefined' ? value : property.item.state;
+  let state = typeof value !== 'undefined' ? value :
+    typeof property.item.state === 'string' ? property.item.state.split(':').shift() : property.item.state;
 
   // Return if state not defined
   if (typeof state === 'undefined') {

--- a/alexa/response.js
+++ b/alexa/response.js
@@ -33,27 +33,26 @@ class AlexaResponse {
    * @return {Object}
    */
   generateResponse(parameters = {}) {
-    return Object.assign({},
-      parameters.context && {
-        // Include context properties if provided
-        context: parameters.context
+    return Object.assign({
+    }, parameters.context && {
+      // Include context properties if provided
+      context: parameters.context
+    }, {
+      // Include event properties
+      event: Object.assign({
+        // Add event header
+        header: this.generateResponseHeader(parameters.header)
+      }, this.directive.endpoint && {
+        // Add event endpoint if provided in directive
+        endpoint: {
+          scope: this.directive.endpoint.scope,
+          endpointId: this.directive.endpoint.endpointId
+        }
       }, {
-        // Include event properties
-        event: Object.assign({
-          // Add event header
-          header: this.generateResponseHeader(parameters.header)
-        }, this.directive.endpoint && {
-          // Add event endpoint if provided in directive
-          endpoint: {
-            scope: this.directive.endpoint.scope,
-            endpointId: this.directive.endpoint.endpointId
-          }
-        }, {
-          // Add event payload
-          payload: parameters.payload || {}
-        })
-      }
-    );
+        // Add event payload
+        payload: parameters.payload || {}
+      })
+    });
   }
 
   /**

--- a/alexa/response.js
+++ b/alexa/response.js
@@ -96,14 +96,47 @@ class AlexaResponse {
 
   /**
    * Returns Alexa generic error response
+   * @param  {Object} error   [error object] (optional)
    */
-  returnAlexaGenericErrorResponse() {
-    this.returnAlexaErrorResponse({
-      payload: {
-        type: 'ENDPOINT_UNREACHABLE',
-        message: 'Unable to reach device'
-      }
-    });
+  returnAlexaGenericErrorResponse(error = {}) {
+    // Set default error response parameters
+    const parameters = {payload: {
+      type: 'ENDPOINT_UNREACHABLE',
+      message: error.cause || 'Unable to reach device'
+    }};
+
+    // Update error response parameters based on request error status code
+    switch (error.statusCode) {
+      case 400:
+        Object.assign(parameters, {payload: {
+          type: 'INVALID_VALUE',
+          message: 'Invalid item command value'
+        }});
+        break;
+      case 401:
+        Object.assign(parameters, {payload: {
+          type: 'INVALID_AUTHORIZATION_CREDENTIAL',
+          message: 'Failed to authenticate'
+        }});
+        break;
+      case 404:
+        // Set to bridge unreachable when oh rest server not accessible, otherwise no such endpoint for items not found
+        if (!error.response.body || error.response.body.includes('Problem accessing')) {
+          Object.assign(parameters, {payload: {
+            type: 'BRIDGE_UNREACHABLE',
+            message: 'Server not accessible'
+          }});
+        } else {
+          Object.assign(parameters, {payload: {
+            type: 'NO_SUCH_ENDPOINT',
+            message: 'Item not found'
+          }});
+        }
+        break;
+    }
+
+    // Return alexa error response
+    this.returnAlexaErrorResponse(parameters);
   }
 }
 

--- a/alexa/v3/brightnessController.js
+++ b/alexa/v3/brightnessController.js
@@ -33,7 +33,7 @@ class AlexaBrightnessController extends AlexaDirective {
    * Set brightness
    */
   setBrightness() {
-    const postItem = Object.assign(this.propertyMap.BrightnessController.brightness.item, {
+    const postItem = Object.assign({}, this.propertyMap.BrightnessController.brightness.item, {
       state: this.directive.payload.brightness
     });
     this.postItemsAndReturn([postItem]);
@@ -43,7 +43,7 @@ class AlexaBrightnessController extends AlexaDirective {
    * Adjust brightness
    */
   adjustBrightness() {
-    const postItem = this.propertyMap.BrightnessController.brightness.item;
+    const postItem = Object.assign({}, this.propertyMap.BrightnessController.brightness.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number

--- a/alexa/v3/brightnessController.js
+++ b/alexa/v3/brightnessController.js
@@ -48,7 +48,7 @@ class AlexaBrightnessController extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       const state = parseInt(item.state) + this.directive.payload.brightnessDelta;
@@ -56,7 +56,7 @@ class AlexaBrightnessController extends AlexaDirective {
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustBrightness failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/channelController.js
+++ b/alexa/v3/channelController.js
@@ -41,7 +41,7 @@ class AlexaChannelController extends AlexaDirective {
       name => name.toUpperCase() === channelName.toUpperCase())
     const channelNumber = channelIndex !== -1 ?
       Object.values(properties.channel.parameters)[channelIndex] : this.directive.payload.channel.number;
-    const postItem = Object.assign(properties.channel.item, {
+    const postItem = Object.assign({}, properties.channel.item, {
       state: channelNumber
     });
 
@@ -62,7 +62,7 @@ class AlexaChannelController extends AlexaDirective {
    * Adjusts channel number
    */
   adjustChannel() {
-    const postItem = this.propertyMap.ChannelController.channel.item;
+    const postItem = Object.assign({}, this.propertyMap.ChannelController.channel.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number

--- a/alexa/v3/channelController.js
+++ b/alexa/v3/channelController.js
@@ -67,14 +67,14 @@ class AlexaChannelController extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       postItem.state = parseInt(item.state) + this.directive.payload.channelCount;
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustChannel failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/colorController.js
+++ b/alexa/v3/colorController.js
@@ -36,7 +36,7 @@ class AlexaColorController extends AlexaDirective {
       this.directive.payload.color.saturation * 100.0,
       this.directive.payload.color.brightness * 100.0
     ];
-    const postItem = Object.assign(this.propertyMap.ColorController.color.item, {
+    const postItem = Object.assign({}, this.propertyMap.ColorController.color.item, {
       state: hsb.join(',')
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/colorTemperatureController.js
+++ b/alexa/v3/colorTemperatureController.js
@@ -36,7 +36,7 @@ class AlexaColorTemperatureController extends AlexaDirective {
    */
   setColorTemperature() {
     const properties = this.propertyMap.ColorTemperatureController;
-    const postItem = Object.assign(properties.colorTemperatureInKelvin.item, {
+    const postItem = Object.assign({}, properties.colorTemperatureInKelvin.item, {
       state: normalize(properties.colorTemperatureInKelvin, this.directive.payload.colorTemperatureInKelvin)
     });
     this.postItemsAndReturn([postItem]);
@@ -47,7 +47,7 @@ class AlexaColorTemperatureController extends AlexaDirective {
    */
   adjustColorTemperature() {
     const properties = this.propertyMap.ColorTemperatureController;
-    const postItem = properties.colorTemperatureInKelvin.item;
+    const postItem = Object.assign({}, properties.colorTemperatureInKelvin.item);
 
     this.getItemState(postItem).then((item) => {
       // Generate error if in color mode (color controller property defined & empty state)

--- a/alexa/v3/colorTemperatureController.js
+++ b/alexa/v3/colorTemperatureController.js
@@ -64,7 +64,7 @@ class AlexaColorTemperatureController extends AlexaDirective {
       }
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       const isIncreaseRequest = this.directive.header.name === 'IncreaseColorTemperature';
@@ -92,7 +92,7 @@ class AlexaColorTemperatureController extends AlexaDirective {
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustColorTemperature failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/discovery.js
+++ b/alexa/v3/discovery.js
@@ -231,7 +231,7 @@ function convertV2Item(item, config = {}) {
           }
           break;
         default:
-          if (isSupportedDisplayCategory(label)) {
+          if (isSupportedDisplayCategory(decamelize(label))) {
             capabilities = ['Endpoint.' + label];
           }
       }
@@ -295,6 +295,21 @@ function convertV2Item(item, config = {}) {
         case 'MotionSensor':
           capabilities = ['MotionSensor.detectionState'];
           break;
+        case 'SecurityAlarmMode':
+          capabilities = ['SecurityPanelController.armState'];
+          break;
+        case 'BurglaryAlarm':
+          capabilities = ['SecurityPanelController.burglaryAlarm'];
+          break;
+        case 'FireAlarm':
+          capabilities = ['SecurityPanelController.fireAlarm'];
+          break;
+        case 'CarbonMonoxideAlarm':
+          capabilities = ['SecurityPanelController.carbonMonoxideAlarm'];
+          break;
+        case 'WaterAlarm':
+          capabilities = ['SecurityPanelController.waterAlarm'];
+          break;
         case 'ModeComponent':
           capabilities = ['ModeController.mode'];
           break;
@@ -323,7 +338,7 @@ function convertV2Item(item, config = {}) {
   }
 
   // Update item alexa metadata information
-  item.metadata = Object.assign(item.metadata, {
+  Object.assign(item.metadata, {
     alexa: {
       value: metadata.values.join(','),
       config: metadata.config

--- a/alexa/v3/discovery.js
+++ b/alexa/v3/discovery.js
@@ -151,7 +151,7 @@ class AlexaDiscovery extends AlexaDirective {
       this.returnAlexaResponse(response);
     }).catch((error) => {
       log.error('discover failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 

--- a/alexa/v3/inputController.js
+++ b/alexa/v3/inputController.js
@@ -31,7 +31,7 @@ class AlexaInputController extends AlexaDirective {
    * Select input (HDMI1, Music, etc..)
    */
   selectInput() {
-    const postItem = Object.assign(this.propertyMap.InputController.input.item, {
+    const postItem = Object.assign({}, this.propertyMap.InputController.input.item, {
       state: this.directive.payload.input.replace(/\s/g, '').toUpperCase()
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/lockController.js
+++ b/alexa/v3/lockController.js
@@ -33,7 +33,7 @@ class AlexaLockController extends AlexaDirective {
    */
   setLockState() {
     const properties = this.propertyMap.LockController;
-    const postItem = Object.assign(properties.lockState.item, {
+    const postItem = Object.assign({}, properties.lockState.item, {
       state: this.directive.header.name.toUpperCase() === 'LOCK' ? 'ON' : 'OFF'
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/modeController.js
+++ b/alexa/v3/modeController.js
@@ -48,7 +48,7 @@ class AlexaModeController extends AlexaDirective {
     // Append instance name to interface property
     this.interface += ':' + this.directive.header.instance;
     const properties = this.propertyMap[this.interface];
-    const postItem = properties.mode.item;
+    const postItem = Object.assign({}, properties.mode.item);
 
     this.getItemState(postItem).then((item) => {
       // Define supported modes list stripping alternate names

--- a/alexa/v3/modeController.js
+++ b/alexa/v3/modeController.js
@@ -58,7 +58,7 @@ class AlexaModeController extends AlexaDirective {
 
       // Throw error if current mode not found
       if (index === -1 ) {
-        throw {reason: 'Current mode not found in supported list', item: item, supported: supportedModes};
+        throw {cause: 'Current mode not found in supported list', item: item, supported: supportedModes};
       }
 
       // Set adjusted mode
@@ -76,7 +76,7 @@ class AlexaModeController extends AlexaDirective {
       }
     }).catch((error) => {
       log.error('adjustMode failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/percentageController.js
+++ b/alexa/v3/percentageController.js
@@ -33,7 +33,7 @@ class AlexaPercentageController extends AlexaDirective {
    * Set percentage
    */
   setPercentage() {
-    const postItem = Object.assign(this.propertyMap.PercentageController.percentage.item, {
+    const postItem = Object.assign({}, this.propertyMap.PercentageController.percentage.item, {
       state: this.directive.payload.percentage
     });
     this.postItemsAndReturn([postItem]);
@@ -43,7 +43,7 @@ class AlexaPercentageController extends AlexaDirective {
    * Adjust percentage
    */
   adjustPercentage() {
-    const postItem = this.propertyMap.PercentageController.percentage.item;
+    const postItem = Object.assign({}, this.propertyMap.PercentageController.percentage.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number

--- a/alexa/v3/percentageController.js
+++ b/alexa/v3/percentageController.js
@@ -48,7 +48,7 @@ class AlexaPercentageController extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       const state = parseInt(item.state) + this.directive.payload.percentageDelta;
@@ -56,7 +56,7 @@ class AlexaPercentageController extends AlexaDirective {
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustPercentage failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/playbackController.js
+++ b/alexa/v3/playbackController.js
@@ -38,7 +38,7 @@ class AlexaPlaybackController extends AlexaDirective {
    * Sends a playback command (PLAY, PASUE, REWIND, etc..) to a string or player item
    */
   setPlayback() {
-    const postItem = Object.assign(this.propertyMap.PlaybackController.playbackState.item, {
+    const postItem = Object.assign({}, this.propertyMap.PlaybackController.playbackState.item, {
       state: this.directive.header.name.toUpperCase()
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/powerController.js
+++ b/alexa/v3/powerController.js
@@ -32,7 +32,7 @@ class AlexaPowerController extends AlexaDirective {
    * Turns a Switch ON or OFF
    */
   setPowerState () {
-    const postItem = Object.assign(this.propertyMap.PowerController.powerState.item, {
+    const postItem = Object.assign({}, this.propertyMap.PowerController.powerState.item, {
       state: this.directive.header.name === 'TurnOn' ? 'ON' : 'OFF'
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/powerLevelController.js
+++ b/alexa/v3/powerLevelController.js
@@ -33,7 +33,7 @@ class AlexaPowerLevelController extends AlexaDirective {
    * Set power level
    */
   setPowerLevel() {
-    const postItem = Object.assign(this.propertyMap.PowerLevelController.powerLevel.item, {
+    const postItem = Object.assign({}, this.propertyMap.PowerLevelController.powerLevel.item, {
       state: this.directive.payload.powerLevel
     });
     this.postItemsAndReturn([postItem]);
@@ -43,7 +43,7 @@ class AlexaPowerLevelController extends AlexaDirective {
    * Adjust power level
    */
   adjustPowerLevel() {
-    const postItem = this.propertyMap.PowerLevelController.powerLevel.item;
+    const postItem = Object.assign({}, this.propertyMap.PowerLevelController.powerLevel.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number

--- a/alexa/v3/powerLevelController.js
+++ b/alexa/v3/powerLevelController.js
@@ -48,7 +48,7 @@ class AlexaPowerLevelController extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       const state = parseInt(item.state) + this.directive.payload.powerLevelDelta;
@@ -56,7 +56,7 @@ class AlexaPowerLevelController extends AlexaDirective {
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustPowerLevel failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/rangeController.js
+++ b/alexa/v3/rangeController.js
@@ -34,7 +34,7 @@ class AlexaRangeController extends AlexaDirective {
   setRangeValue() {
     // Append instance name to interface property
     this.interface += ':' + this.directive.header.instance;
-    const postItem = Object.assign(this.propertyMap[this.interface].rangeValue.item, {
+    const postItem = Object.assign({}, this.propertyMap[this.interface].rangeValue.item, {
       state: this.directive.payload.rangeValue
     });
     this.postItemsAndReturn([postItem]);
@@ -47,7 +47,7 @@ class AlexaRangeController extends AlexaDirective {
     // Append instance name to interface property
     this.interface += ':' + this.directive.header.instance;
     const properties = this.propertyMap[this.interface]
-    const postItem = properties.rangeValue.item;
+    const postItem = Object.assign({}, properties.rangeValue.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number

--- a/alexa/v3/rangeController.js
+++ b/alexa/v3/rangeController.js
@@ -52,7 +52,7 @@ class AlexaRangeController extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       const minRange = properties.rangeValue.parameters.supportedRange.minimumValue;
@@ -62,7 +62,7 @@ class AlexaRangeController extends AlexaDirective {
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustRangeValue failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 }

--- a/alexa/v3/sceneController.js
+++ b/alexa/v3/sceneController.js
@@ -34,7 +34,7 @@ class AlexaSceneController extends AlexaDirective {
    */
   setScene() {
     const isSceneActivate = this.directive.header.name === 'Activate';
-    const postItem = Object.assign(this.propertyMap.SceneController.scene.item, {
+    const postItem = Object.assign({}, this.propertyMap.SceneController.scene.item, {
       state: isSceneActivate ? 'ON' : 'OFF'
     });
     const response = this.generateResponse({

--- a/alexa/v3/securityPanelController.js
+++ b/alexa/v3/securityPanelController.js
@@ -74,7 +74,7 @@ class AlexaSecurityPanelController extends AlexaDirective {
       }
     }).catch((error) => {
       log.error('arm failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 

--- a/alexa/v3/securityPanelController.js
+++ b/alexa/v3/securityPanelController.js
@@ -7,7 +7,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
+const log = require('@lib/log.js');
 const AlexaDirective = require('../directive.js');
+const { normalize } = require('../propertyState.js');
 
 /**
  * Defines Alexa.SecurityPanelController interface directive class
@@ -23,9 +25,118 @@ class AlexaSecurityPanelController extends AlexaDirective {
     super(directive, callback);
     this.interface = 'SecurityPanelController';
     this.map = {
-      arm: undefined,
-      disarm: undefined
+      arm: 'arm',
+      disarm: 'disarm'
     };
+  }
+
+  /**
+   * Arm security panel
+   */
+  arm() {
+    const armState = this.directive.payload.armState;
+    const properties = this.propertyMap.SecurityPanelController;
+    const postItem = Object.assign({}, properties.armState.item, {
+      state: normalize(properties.armState, armState)
+    });
+    let exitDelay;
+
+    if (armState === 'ARMED_AWAY') {
+      // Set exit delay to defined parameter value only if arm away request
+      exitDelay = parseInt(properties.armState.parameters.exitDelay);
+      // Append 'instant' to post item state and set exit delay to zero if arm away request and arm instant enabled
+      if (this.directive.payload.isArmInstant === true) {
+        postItem.state += ':instant';
+        exitDelay = 0;
+      }
+    }
+
+    this.getItemState(postItem).then((item) => {
+      // Convert current item state to alexa state
+      const currentState = normalize(properties.armState, item.state);
+
+      // Return authorization required error when currently in armed away state and request to arm stay or night
+      if (currentState === 'ARMED_AWAY' && ['ARMED_STAY', 'ARMED_NIGHT'].includes(armState)) {
+        this.returnAlexaErrorResponse(
+          this.armStateErrorResponse('AUTHORIZATION_REQUIRED')
+        );
+      } else {
+        this.postItemsAndReturn([postItem], {
+          header: {
+            'namespace': this.directive.header.namespace,
+            'name': 'Arm.Response'
+          },
+          payload: isNaN(exitDelay) ? {} : {
+            'exitDelayInSeconds': exitDelay
+          },
+          properties: ['armState']
+        });
+      }
+    }).catch((error) => {
+      log.error('arm failed with error:', error);
+      this.returnAlexaGenericErrorResponse();
+    });
+  }
+
+  /**
+   * Disarm security panel
+   */
+  disarm() {
+    const properties = this.propertyMap.SecurityPanelController;
+    const postItem = Object.assign({}, properties.armState.item, {
+      state: normalize(properties.armState, 'DISARMED')
+    });
+
+    // Append pin code to post item state if authorization code provided and pin type
+    if (this.directive.payload.authorization && this.directive.payload.authorization.type === 'FOUR_DIGIT_PIN') {
+      postItem.state += ':' + this.directive.payload.authorization.value;
+    }
+
+    this.postItemsAndReturn([postItem], {properties: ['armState']});
+  }
+
+  /**
+   * Returns arm state error response based on given state
+   * @param  {String} state
+   * @return {Object}
+   */
+  armStateErrorResponse(state) {
+    const response = {
+      namespace: this.directive.header.namespace
+    };
+
+    switch (state) {
+      case 'AUTHORIZATION_REQUIRED':
+        return Object.assign(response, {payload: {
+          type: 'AUTHORIZATION_REQUIRED',
+          message: 'Unable to arm the security panel because authorization is required'
+        }});
+      case 'BYPASS_NEEDED':
+        return Object.assign(response, {payload: {
+          type: 'BYPASS_NEEDED',
+          message: 'Unable to arm the security panel because it has open zones that must be bypassed'
+        }});
+      case 'NOT_READY':
+        return Object.assign(response, {payload: {
+          type: 'NOT_READY',
+          message: 'Unable to arm or disarm the security panel because it is not ready'
+        }});
+      case 'UNAUTHORIZED':
+        return Object.assign(response, {payload: {
+          type: 'UNAUTHORIZED',
+          message: 'Unable to disarm the security panel because the PIN code is not correct'
+        }});
+      case 'UNCLEARED_ALARM':
+        return Object.assign(response, {payload: {
+          type: 'UNCLEARED_ALARM',
+          message: 'Unable to arm the security panel because it is in alarm status'
+        }});
+      case 'UNCLEARED_TROUBLE':
+        return Object.assign(response, {payload: {
+          type: 'UNCLEARED_TROUBLE',
+          message: 'Unable to arm the security panel because it is in trouble status'
+        }});
+    }
   }
 }
 

--- a/alexa/v3/speaker.js
+++ b/alexa/v3/speaker.js
@@ -54,14 +54,14 @@ class AlexaSpeaker extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       postItem.state = parseInt(item.state) + volumeIncrement;
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustVolume failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 

--- a/alexa/v3/speaker.js
+++ b/alexa/v3/speaker.js
@@ -34,7 +34,7 @@ class AlexaSpeaker extends AlexaDirective {
    * Set volume
    */
   setVolume() {
-    const postItem = Object.assign(this.propertyMap.Speaker.volume.item, {
+    const postItem = Object.assign({}, this.propertyMap.Speaker.volume.item, {
       state: this.directive.payload.volume
     });
     this.postItemsAndReturn([postItem]);
@@ -44,7 +44,7 @@ class AlexaSpeaker extends AlexaDirective {
    * Adjust volume
    */
   adjustVolume() {
-    const postItem = this.propertyMap.Speaker.volume.item;
+    const postItem = Object.assign({}, this.propertyMap.Speaker.volume.item);
     const defaultIncrement = parseInt(this.propertyMap.Speaker.volume.parameters.increment);
     const volumeAdjust = this.directive.payload.volume;
     const volumeDefault = this.directive.payload.volumeDefault;
@@ -69,7 +69,7 @@ class AlexaSpeaker extends AlexaDirective {
    * Set Mute
    */
   setMute() {
-    const postItem = Object.assign(this.propertyMap.Speaker.muted.item, {
+    const postItem = Object.assign({}, this.propertyMap.Speaker.muted.item, {
       state: this.directive.payload.mute ? 'ON' : 'OFF'
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/stepSpeaker.js
+++ b/alexa/v3/stepSpeaker.js
@@ -38,14 +38,14 @@ class AlexaStepSpeaker extends AlexaDirective {
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
       if (isNaN(item.state)) {
-        throw {reason: 'Could not get numeric item state', item: item};
+        throw {cause: 'Could not get numeric item state', item: item};
       }
 
       postItem.state = parseInt(item.state) + this.directive.payload.volumeSteps;
       this.postItemsAndReturn([postItem]);
     }).catch((error) => {
       log.error('adjustVolume failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 

--- a/alexa/v3/stepSpeaker.js
+++ b/alexa/v3/stepSpeaker.js
@@ -33,7 +33,7 @@ class AlexaStepSpeaker extends AlexaDirective {
    * Adjust volume
    */
   adjustVolume() {
-    const postItem = this.propertyMap.StepSpeaker.volume.item;
+    const postItem = Object.assign({}, this.propertyMap.StepSpeaker.volume.item);
 
     this.getItemState(postItem).then((item) => {
       // Throw error if state not a number
@@ -53,7 +53,7 @@ class AlexaStepSpeaker extends AlexaDirective {
    * Set mute
    */
   setMute() {
-    const postItem = Object.assign(this.propertyMap.StepSpeaker.muted.item, {
+    const postItem = Object.assign({}, this.propertyMap.StepSpeaker.muted.item, {
       state: this.directive.payload.mute ? 'ON' : 'OFF'
     });
     this.postItemsAndReturn([postItem]);

--- a/alexa/v3/thermostatController.js
+++ b/alexa/v3/thermostatController.js
@@ -106,7 +106,7 @@ class AlexaThermostatController extends AlexaDirective {
       this.postItemsAndReturn(postItems);
     }).catch((error) => {
       log.error('adjustTargetTemperature failed with error:', error);
-      this.returnAlexaGenericErrorResponse();
+      this.returnAlexaGenericErrorResponse(error);
     });
   }
 

--- a/alexa/v3/thermostatController.js
+++ b/alexa/v3/thermostatController.js
@@ -42,7 +42,7 @@ class AlexaThermostatController extends AlexaDirective {
     // Add requested properties to be updated that are part of the controller properties
     const postItems = Object.keys(properties).reduce((items, propertyName) => {
       if (directive.payload[propertyName]) {
-        items.push(Object.assign(properties[propertyName].item, {
+        items.push(Object.assign({}, properties[propertyName].item, {
           state: normalize(properties[propertyName], directive.payload[propertyName])
         }));
       }
@@ -65,10 +65,10 @@ class AlexaThermostatController extends AlexaDirective {
       }
       // set dual setpoints
       postItems.push(
-        Object.assign(properties.upperSetpoint.item, {
+        Object.assign({}, properties.upperSetpoint.item, {
           state: normalize(properties.upperSetpoint, directive.payload.targetSetpoint) + upperRange
         }),
-        Object.assign(properties.lowerSetpoint.item, {
+        Object.assign({}, properties.lowerSetpoint.item, {
           state: normalize(properties.lowerSetpoint, directive.payload.targetSetpoint) - lowerRange
         })
       );
@@ -95,7 +95,7 @@ class AlexaThermostatController extends AlexaDirective {
     }
     propertyNames.forEach((propertyName) => {
       promises.push(this.getItemState(properties[propertyName].item).then(item =>
-        Object.assign(properties[propertyName].item, {
+        Object.assign({}, properties[propertyName].item, {
           state: parseFloat(item.state) + normalize(properties[propertyName],
             this.directive.payload.targetSetpointDelta, {isDelta: true})
         })
@@ -115,7 +115,7 @@ class AlexaThermostatController extends AlexaDirective {
    */
   setThermostatMode() {
     const properties = this.propertyMap.ThermostatController;
-    const postItem = Object.assign(properties.thermostatMode.item, {
+    const postItem = Object.assign({}, properties.thermostatMode.item, {
       state: normalize(properties.thermostatMode, this.directive.payload.thermostatMode.value)
     });
 

--- a/alexa/v3/toggleController.js
+++ b/alexa/v3/toggleController.js
@@ -34,7 +34,7 @@ class AlexaToggleController extends AlexaDirective {
   setToggleState() {
     // Append instance name to interface property
     this.interface += ':' + this.directive.header.instance;
-    const postItem = Object.assign(this.propertyMap[this.interface].toggleState.item, {
+    const postItem = Object.assign({}, this.propertyMap[this.interface].toggleState.item, {
       state: this.directive.header.name === 'TurnOn' ? 'ON' : 'OFF'
     });
     this.postItemsAndReturn([postItem]);

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -18,7 +18,7 @@ const config = getConfig();
  */
 function getConfig() {
   // Default configuration
-  const defaults = {
+  const config = {
     openhab: {
       baseURL: process.env.OPENHAB_BASE_URL || 'https://localhost:8443/rest',
       user: process.env.OPENHAB_USERNAME || null,
@@ -26,7 +26,7 @@ function getConfig() {
     }
   };
   // Merge config file settings with default ones
-  const config = Object.assign(defaults, getConfigFileSettings());
+  Object.assign(config, getConfigFileSettings());
   // Merge username & password if specified
   if (config.openhab.user && config.openhab.pass) {
     config.openhab.userpass = `${config.openhab.user}:${config.openhab.pass}`;

--- a/test/common.js
+++ b/test/common.js
@@ -178,7 +178,7 @@ assert.capturedCalls = function (calls, expected) {
 assert.capturedResult = function (result, expected) {
   if (expected) {
     Object.keys(expected).forEach((key) => {
-      if (typeof expected[key] === 'object') {
+      if (typeof expected[key] === 'object' && expected[key] !== null) {
         assert.exists(result[key]);
         assert.capturedResult(result[key], expected[key]);
       } else {

--- a/test/settings.js
+++ b/test/settings.js
@@ -15,6 +15,9 @@ var settings = {
       "Scene": [
         "./v3/test_discoverScene.js"
       ],
+      "SecurityPanel": [
+        "./v3/test_discoverSecurityPanel.js"
+      ],
       "Sensor": [
         "./v3/test_discoverSensor.js"
       ],
@@ -86,6 +89,9 @@ var settings = {
       ],
       "SceneController": [
         "./v3/test_controllerScene.js"
+      ],
+      "SecurityPanelController": [
+        "./v3/test_controllerSecurityPanel.js"
       ],
       "Speaker": [
         "./v3/test_controllerSpeaker.js"

--- a/test/v3/test_controllerAlexa.js
+++ b/test/v3/test_controllerAlexa.js
@@ -109,6 +109,68 @@ module.exports = [
     }
   },
   {
+    description: "report state partial thermostat group",
+    directive: {
+      "header": {
+        "namespace": "Alexa",
+        "name": "ReportState"
+      },
+      "endpoint": {
+        "endpointId": "temperature1",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "ThermostatController": {
+              "targetSetpoint": {"parameters": {"scale": "Fahrenheit"},
+                "item": {"name": "targetTemperature", "type": "Number"}, "schema": {"name": "temperature"}},
+              "upperSetpoint": {"parameters": {"scale": "Fahrenheit"},
+                "item": {"name": "highTargetTemperature", "type": "Number"}, "schema": {"name": "temperature"}},
+              "lowerSetpoint": {"parameters": {"scale": "Fahrenheit"},
+                "item": {"name": "lowTargetTemperature", "type": "Number"}, "schema": {"name": "temperature"}}
+            }
+          })
+        }
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "targetTemperature", "state": "70", "type": "Number"},
+        {"name": "highTargetTemperature", "state": "NULL", "type": "Number"},
+        {"name": "lowTargetTemperature", "state": "UNDEF", "type": "Number"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [
+            {
+              "namespace": "Alexa.ThermostatController",
+              "name": "targetSetpoint",
+              "value": {
+                "value": 70.0,
+                "scale": "FAHRENHEIT"
+              }
+            },
+            {
+              "namespace": "Alexa.EndpointHealth",
+              "name": "connectivity",
+              "value": {
+                "value": "UNREACHABLE"
+              }
+            }
+          ]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "StateReport"
+          },
+        }
+      },
+      openhab: []
+    }
+  },
+  {
     description: "report state unreachable error",
     directive: {
       "header": {
@@ -138,7 +200,7 @@ module.exports = [
           },
           "payload": {
             "type": "ENDPOINT_UNREACHABLE",
-            "message": "Unable to reach device"
+            "message": "Unable to get context properties response"
           }
         }
       },

--- a/test/v3/test_controllerSecurityPanel.js
+++ b/test/v3/test_controllerSecurityPanel.js
@@ -1,0 +1,494 @@
+module.exports = [
+  {
+    description: "arm away instant string item",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Arm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              },
+              "burglaryAlarm": {
+                "parameters": {},
+                "item": {"name": "BurglaryAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "armState": "ARMED_AWAY",
+        "isArmInstant": true
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "AlarmMode", "state": "disarm", "type": "String"},
+        {"name": "AlarmMode", "state": "away:instant", "type": "String"},
+        {"name": "BurglaryAlarm", "state": "OFF", "type": "Switch"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "armState",
+            "value": "ARMED_AWAY"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "Arm.Response"
+          },
+          "payload": {
+            "exitDelayInSeconds": 0
+          }
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": "away:instant"}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "arm away delay string item",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Arm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "armState": "ARMED_AWAY",
+        "isArmInstant": false
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "AlarmMode", "state": "disarm", "type": "String"},
+        {"name": "AlarmMode", "state": "away", "type": "String"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "armState",
+            "value": "ARMED_AWAY"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "Arm.Response"
+          },
+          "payload": {
+            "exitDelayInSeconds": 180
+          }
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": "away"}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "arm stay no delay number item",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Arm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "DISARMED": 0, "ARMED_STAY": 1, "ARMED_AWAY": 2, "exitDelay": 180,
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"]},
+                "item": {"name": "AlarmMode", "type": "Number"},
+                "schema": {"name": "armState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "armState": "ARMED_STAY"
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "AlarmMode", "state": "0", "type": "Number"},
+        {"name": "AlarmMode", "state": "1", "type": "Number"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "armState",
+            "value": "ARMED_STAY"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "Arm.Response"
+          },
+          "payload": {}
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": 1}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "arm authorization required error",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Arm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "armState": "ARMED_STAY",
+        "isArmInstant": false
+      }
+    },
+    mocked: {
+      openhab: {"name": "AlarmMode", "state": "away", "type": "String"}
+    },
+    expected: {
+      alexa: {
+        "event": {
+          "header": {
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "ErrorResponse"
+          },
+          "payload": {
+            "type": "AUTHORIZATION_REQUIRED",
+            "message": "Unable to arm the security panel because authorization is required"
+          }
+        }
+      },
+      openhab: []
+    },
+    validate: false
+  },
+  {
+    description: "disarm with pin code",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Disarm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              },
+              "burglaryAlarm": {
+                "parameters": {},
+                "item": {"name": "BurglaryAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "authorization": {
+          "type": "FOUR_DIGIT_PIN",
+          "value": "1234"
+        }
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "AlarmMode", "state": "disarm:1234", "type": "String"},
+        {"name": "BurglaryAlarm", "state": "OFF", "type": "Switch"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "armState",
+            "value": "DISARMED"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          }
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": "disarm:1234"}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "disarm no pin code",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Disarm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": false, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {}
+    },
+    mocked: {
+      openhab: {"name": "AlarmMode", "state": "disarm", "type": "String"}
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "armState",
+            "value": "DISARMED"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          }
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": "disarm"}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "disarm unauthorized error",
+    directive: {
+      "header": {
+        "namespace": "Alexa.SecurityPanelController",
+        "name": "Disarm",
+      },
+      "endpoint": {
+        "endpointId": "AlarmMode",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+                  "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+                "item": {"name": "AlarmMode", "type": "String"},
+                "schema": {"name": "armState"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "authorization": {
+          "type": "FOUR_DIGIT_PIN",
+          "value": "1234"
+        }
+      }
+    },
+    mocked: {
+      openhab: {"name": "AlarmMode", "state": "unauth", "type": "String"}
+    },
+    expected: {
+      alexa: {
+        "event": {
+          "header": {
+            "namespace": "Alexa.SecurityPanelController",
+            "name": "ErrorResponse"
+          },
+          "payload": {
+            "type": "UNAUTHORIZED",
+            "message": "Unable to disarm the security panel because the PIN code is not correct"
+          }
+        }
+      },
+      openhab: [
+        {"name": "AlarmMode", "value": "disarm:1234"}
+      ]
+    },
+    validate: false
+  },
+  {
+    description: "alarm state report",
+    directive: {
+      "header": {
+        "namespace": "Alexa",
+        "name": "ReportState"
+      },
+      "endpoint": {
+        "endpointId": "gAlarmSystem",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "SecurityPanelController": {
+              "armState": {
+                "parameters": {
+                  "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"]},
+                "item": {"name": "ArmState", "type": "String"},
+                "schema": {"name": "armState"}
+              },
+              "burglaryAlarm": {
+                "parameters": {},
+                "item": {"name": "BurglaryAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              },
+              "fireAlarm": {
+                "parameters": {},
+                "item": {"name": "FireAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              },
+              "carbonMonoxideAlarm": {
+                "parameters": {},
+                "item": {"name": "CarbonMonoxideAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              },
+              "waterAlarm": {
+                "parameters": {},
+                "item": {"name": "WaterAlarm", "type": "Switch"},
+                "schema": {"name": "alarmState"}
+              }
+            }
+          })
+        }
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "ArmState", "state": "away", "type": "String"},
+        {"name": "BurglaryAlarm", "state": "ON", "type": "Switch"},
+        {"name": "FireAlarm", "state": "OFF", "type": "Switch"},
+        {"name": "CarbonMonoxideAlarm", "state": "OFF", "type": "Switch"},
+        {"name": "WaterAlarm", "state": "OFF", "type": "Switch"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [
+            {
+              "namespace": "Alexa.SecurityPanelController",
+              "name": "armState",
+              "value": "ARMED_AWAY"
+            },
+            {
+              "namespace": "Alexa.SecurityPanelController",
+              "name": "burglaryAlarm",
+              "value": "ALARM"
+            },
+            {
+              "namespace": "Alexa.SecurityPanelController",
+              "name": "fireAlarm",
+              "value": "OK"
+            },
+            {
+              "namespace": "Alexa.SecurityPanelController",
+              "name": "carbonMonoxideAlarm",
+              "value": "OK"
+            },
+            {
+              "namespace": "Alexa.SecurityPanelController",
+              "name": "waterAlarm",
+              "value": "OK"
+            }
+          ]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "StateReport"
+          }
+        }
+      },
+      openhab: []
+    },
+    validate: false
+  }
+];

--- a/test/v3/test_discoverSecurityPanel.js
+++ b/test/v3/test_discoverSecurityPanel.js
@@ -1,0 +1,276 @@
+module.exports = {
+  description: "security panel enabled group",
+  mocked: [
+    {
+      "members": [
+        {
+          "link": "https://myopenhab.org/rest/items/ArmState",
+          "type": "String",
+          "name": "ArmState",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "SecurityPanelController.armState",
+              "config": {
+                "exitDelay": 180,
+                "supportedArmStates": "ARMED_AWAY,ARMED_STAY,DISARMED",
+                "supportsArmInstant": true,
+                "supportsPinCodes": true
+              }
+            }
+          },
+          "groupNames": ["gAlarmSystem"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/BurglaryAlarm",
+          "type": "Switch",
+          "name": "BurglaryAlarm",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "SecurityPanelController.burglaryAlarm"
+            }
+          },
+          "groupNames": ["gAlarmSystem"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/FireAlarm",
+          "type": "Switch",
+          "name": "FireAlarm",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "SecurityPanelController.fireAlarm"
+            }
+          },
+          "groupNames": ["gAlarmSystem"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/CarbonMonoxideAlarm",
+          "type": "Switch",
+          "name": "CarbonMonoxideAlarm",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "SecurityPanelController.carbonMonoxideAlarm"
+            }
+          },
+          "groupNames": ["gAlarmSystem"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/WaterAlarm",
+          "type": "Switch",
+          "name": "WaterAlarm",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "SecurityPanelController.waterAlarm"
+            }
+          },
+          "groupNames": ["gAlarmSystem"]
+        }
+      ],
+      "link": "https://myopenhab.org/rest/items/gAlarmSystem",
+      "type": "Group",
+      "name": "gAlarmSystem",
+      "label": "Alarm System",
+      "tags": [],
+      "metadata": {
+        "alexa": {
+          "value": "Endpoint.SecurityPanel"
+        }
+      },
+      "groupNames": []
+    },
+    { // Number item type state mapping no supportedArmStates
+      "link": "https://myopenhab.org/rest/items/AlarmMode1",
+      "type": "Number",
+      "name": "AlarmMode1",
+      "label": "Alarm Mode",
+      "tags": [],
+      "metadata": {
+        "alexa": {
+          "value": "SecurityPanelController.armState",
+          "config": {
+            "DISARMED": 0,
+            "ARMED_STAY": 1,
+            "ARMED_AWAY": 2,
+            "exitDelay": 300,
+            "supportsArmInstant": true,
+            "supportsPinCodes": true
+          }
+        }
+      },
+      "groupNames": []
+    },
+    { // Switch item type default config
+      "link": "https://myopenhab.org/rest/items/AlarmMode2",
+      "type": "Switch",
+      "name": "AlarmMode2",
+      "label": "Alarm Mode",
+      "tags": [],
+      "metadata": {
+        "alexa": {
+          "value": "SecurityPanelController.armState",
+        }
+      },
+      "groupNames": []
+    },
+    { // No exit delay arm instant enabled
+      "link": "https://myopenhab.org/rest/items/AlarmMode3",
+      "type": "String",
+      "name": "AlarmMode3",
+      "label": "Alarm Mode",
+      "tags": [],
+      "metadata": {
+        "alexa": {
+          "value": "SecurityPanelController.armState",
+          "config": {
+            "supportedArmStates": "ARMED_AWAY,ARMED_STAY,DISARMED",
+            "supportsArmInstant": true
+          }
+        }
+      },
+      "groupNames": []
+    }
+  ],
+  expected: {
+    "gAlarmSystem": {
+      "capabilities": [
+        "Alexa",
+        "Alexa.SecurityPanelController.armState",
+        "Alexa.SecurityPanelController.burglaryAlarm",
+        "Alexa.SecurityPanelController.fireAlarm",
+        "Alexa.SecurityPanelController.carbonMonoxideAlarm",
+        "Alexa.SecurityPanelController.waterAlarm",
+        "Alexa.EndpointHealth.connectivity"
+      ],
+      "displayCategories": ["SECURITY_PANEL"],
+      "friendlyName": "Alarm System",
+      "configuration": {
+        "Alexa.SecurityPanelController": {
+          "supportsArmInstant": true,
+          "supportedArmStates": [
+            {'value': 'ARMED_AWAY'}, {'value': 'ARMED_STAY'}, {'value': 'DISARMED'}
+          ],
+          "supportedAuthorizationTypes": [
+            {'type': 'FOUR_DIGIT_PIN'}
+          ]
+        }
+      },
+      "propertyMap": {
+        "SecurityPanelController": {
+          "armState": {
+            "parameters": {
+              "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"],
+              "supportsArmInstant": true, "supportsPinCodes": true, "exitDelay": 180},
+            "item": {"name": "ArmState", "type": "String"},
+            "schema": {"name": "armState"}
+          },
+          "burglaryAlarm": {
+            "parameters": {},
+            "item": {"name": "BurglaryAlarm", "type": "Switch"},
+            "schema": {"name": "alarmState"}
+          },
+          "fireAlarm": {
+            "parameters": {},
+            "item": {"name": "FireAlarm", "type": "Switch"},
+            "schema": {"name": "alarmState"}
+          },
+          "carbonMonoxideAlarm": {
+            "parameters": {},
+            "item": {"name": "CarbonMonoxideAlarm", "type": "Switch"},
+            "schema": {"name": "alarmState"}
+          },
+          "waterAlarm": {
+            "parameters": {},
+            "item": {"name": "WaterAlarm", "type": "Switch"},
+            "schema": {"name": "alarmState"}
+          }
+        }
+      }
+    },
+    "AlarmMode1": {
+      "capabilities": [
+        "Alexa",
+        "Alexa.SecurityPanelController.armState",
+        "Alexa.EndpointHealth.connectivity"
+      ],
+      "displayCategories": ["SECURITY_PANEL"],
+      "friendlyName": "Alarm Mode",
+      "configuration": {
+        "Alexa.SecurityPanelController": {
+          "supportsArmInstant": false,
+          "supportedArmStates": [
+            {'value': 'DISARMED'}, {'value': 'ARMED_STAY'}, {'value': 'ARMED_AWAY'}
+          ]
+        }
+      },
+      "propertyMap": {
+        "SecurityPanelController": {
+          "armState": {
+            "parameters": {
+              "DISARMED": 0, "ARMED_STAY": 1, "ARMED_AWAY": 2, "exitDelay": 255,
+              "supportedArmStates": ["DISARMED", "ARMED_STAY", "ARMED_AWAY"]},
+            "item": {"name": "AlarmMode1", "type": "Number"},
+            "schema": {"name": "armState"}
+          }
+        }
+      }
+    },
+    "AlarmMode2": {
+      "capabilities": [
+        "Alexa",
+        "Alexa.SecurityPanelController.armState",
+        "Alexa.EndpointHealth.connectivity"
+      ],
+      "displayCategories": ["SECURITY_PANEL"],
+      "friendlyName": "Alarm Mode",
+      "configuration": {
+        "Alexa.SecurityPanelController": {
+          "supportsArmInstant": false,
+          "supportedArmStates": [
+            {'value': 'DISARMED'}, {'value': 'ARMED_STAY'}
+          ]
+        }
+      },
+      "propertyMap": {
+        "SecurityPanelController": {
+          "armState": {
+            "parameters": {
+              "supportedArmStates": ["DISARMED", "ARMED_STAY"]},
+            "item": {"name": "AlarmMode2", "type": "Switch"},
+            "schema": {"name": "armState"}
+          }
+        }
+      }
+    },
+    "AlarmMode3": {
+      "capabilities": [
+        "Alexa",
+        "Alexa.SecurityPanelController.armState",
+        "Alexa.EndpointHealth.connectivity"
+      ],
+      "displayCategories": ["SECURITY_PANEL"],
+      "friendlyName": "Alarm Mode",
+      "configuration": {
+        "Alexa.SecurityPanelController": {
+          "supportsArmInstant": false,
+          "supportedArmStates": [
+            {'value': 'ARMED_AWAY'}, {'value': 'ARMED_STAY'}, {'value': 'DISARMED'}
+          ]
+        }
+      },
+      "propertyMap": {
+        "SecurityPanelController": {
+          "armState": {
+            "parameters": {
+              "supportedArmStates": ["ARMED_AWAY", "ARMED_STAY", "DISARMED"]},
+            "item": {"name": "AlarmMode3", "type": "String"},
+            "schema": {"name": "armState"}
+          }
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Fixes: #111 

**Changes**
* Added ability to restrict the properties included in response context
* Added ability to trigger an error reponse based on properties response name and value
* Moved supported property states into schema config object
* Fixed object not properly cloned causing some reference objects to be unecessarily updated