### PR TITLE
Equalizer Controller Support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -5,7 +5,7 @@ Alexa is an intelligent personal assistant developed by Amazon and designed to r
 
 <p></p>
 
-This certified Amazon Smart Home Skill allows users to naturally control their openHAB powered smart home with natural voice commands.  Lights, locks, thermostats, AV devices, sensors and many other device types can be controled through a user's Alexa powered device like the Echo or Dot.
+This certified Amazon Smart Home Skill allows users to naturally control their openHAB powered smart home with natural voice commands.  Lights, locks, thermostats, AV devices, sensors and many other device types can be controlled through a user's Alexa powered device like the Echo or Dot.
 
 <p></p>
 
@@ -32,18 +32,18 @@ The skill connects your openHAB setup through the [myopenHAB.org](http://myopenH
     * [Item State](#Item-State)
     * [Item Unit of Measurement](#Item-Unit-of-Measurement)
     * [Supported Item Metadata](#Supported-Item-Metadata)
-    * [Item Categories](#Item-Categories)
-    * [Asset Catalog](#Asset-Catalog)
-    * [Friendly Names Not Allowed](#Friendly-Names-Not-Allowed)
-    * [Unit of Measurement Catalog](#Unit-of-Measurement-Catalog)
+      * [Display Categories](#Display-Categories)
+      * [Asset Catalog](#Asset-Catalog)
+      * [Friendly Names Not Allowed](#Friendly-Names-Not-Allowed)
+      * [Unit of Measurement Catalog](#Unit-of-Measurement-Catalog)
     * [Supported Group Metadata](#Supported-Group-Metadata)
-    * [Label Support](#Label-Support)
+    * [Supported Labels](#Supported-Labels)
   *  [Version 2 Item mapping](#Version-2-Item-mapping)
 * [Example Voice Commands](#Example-Voice-Commands)
 
 ## Other openHAB Alexa Integrations
 
-openHAB has two other Alexa integrations that can be used in conjunction with or indepently of this skill.
+openHAB has two other Alexa integrations that can be used in conjunction with or independently of this skill.
 
 ### Amazon Echo Control Binding
 
@@ -88,17 +88,17 @@ Here are some of the most common generic errors you may encounter while using th
 #### Server Not Accessible
 * Alexa will respond with "Sorry the hub that _device_ is connected to is not responding, please check its network connection and power supply"
 * It indicates that your openHAB server is not accessible through [myopenHAB](https://myopenhab.org) cloud service.
-* To resolve this error, make sure that your server is running and showing online under your myopenHAB account. For users that have setup their own custom skill, make sure that the proper server base url was added to the lambda function config.js.
+* To resolve this error, make sure that your server is running and showing online under your myopenHAB account. For users that have setup their own custom skill, make sure that the proper server base URL was added to the lambda function config.js.
 
 ## Setup
 
 * NEW Alexa Version 3 API syntax (v3)
   * Version 3 of the Alex Skill API introduces a more rich and complex set of features that required a change in how items are configured by using the new metadata feature introduced in openaHAB 2.3
   * Version 2 tags are still supported and are converted internally to V3 meta data
-  * See [Label Support](#Label-Support) for using labels in item tags and meta data.
-  * Supported [item](#supported-item-metadata) & [group](#supported-group-metadata) V3 meta data
-  * Automatically determine number precision and unit based on [item state presentation](#item-state) and [unit of measurement](#item-unit-of-measurement).
-  * Decoupling between item receiving command and item state via an [item sensor](#item-sensor)
+  * See [supported labels](#Supported-Labels) for using them in item tags and meta data.
+  * Supported [item](#Supported-Item-Metadata) & [group](#Supported-Group-Metadata) V3 meta data
+  * Automatically determine number precision and unit based on [item state presentation](#Item-State) and [unit of measurement](#Item-Unit-of-Measurement).
+  * Decoupling between item receiving command and item state via an [item sensor](#Item-Sensor)
   * Improved Alexa response state accuracy
 
 ### Item Label Recommendation
@@ -137,7 +137,7 @@ While single mapping items works for many use cases, occasionally multiple openH
 
 For this example we will use various use cases, a thermostat, a stereo, a security system, a washer and a fan.
 
-In openHAB a thermostat is modeled as many different items, typically there are items for set points (target, heat, cool), modes, and the current temperature. To map these items to a single endpoint in Alexa, we will add them to a group which also uses "Alexa" metadata. When items are alexa-enabled, but are also a member of a group alexa-enabled, they will be added to the group endpoint and not exposed as their own endpoints.
+In openHAB a thermostat is modeled as many different items, typically there are items for set points (target, heat, cool), modes, and the current temperature. To map these items to a single endpoint in Alexa, we will add them to a group which also uses "Alexa" metadata. When items are Alexa-enabled, but are also a member of a group Alexa-enabled, they will be added to the group endpoint and not exposed as their own endpoints.
 
 ```
 Group  Thermostat    "Bedroom"                                {alexa="Endpoint.Thermostat"}
@@ -169,6 +169,10 @@ Switch Power    "Power"   (Stereo)  {alexa="PowerController.powerState"}
 String Input    "Input"   (Stereo)  {alexa="InputController.input" [supportedInputs="HDMI1,TV"]}
 String Channel  "Channel" (Stereo)  {alexa="ChannelController.channel"}
 Player Player   "Player"  (Stereo)  {alexa="PlaybackController.playbackState"}
+Number Bass     "Bass"    (Stereo)  {alexa="EqualizerController.bands:bass" [range="-10:10"]}
+Number Midrange "Mid"     (Stereo)  {alexa="EqualizerController.bands:midrange" [range="-10:10"]}
+Number Treble   "Treble"  (Stereo)  {alexa="EqualizerController.bands:treble" [range="-10:10"]}
+String Mode     "Mode"    (Stereo)  {alexa="EqualizerController.modes" [supportedModes="MOVIE,MUSIC,TV"]}
 ```
 
 A security system is another example including alarm mode and different alarm states.
@@ -263,7 +267,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * Fahrenheit
         * Kelvin
       * comfortRange=`<number>`
-        * When dual setpoints (upper,lower) are used this is the amount over the requested temperature when requesting Alexa to set or adjust the current temperature.  Defaults to comfortRange=1 if using Fahrenheit and comfortRange=.5 if using Celsius. Ignored if a targetSetpoint is included in the thermostat group.
+        * When dual setpoints (upper, lower) are used this is the amount over the requested temperature when requesting Alexa to set or adjust the current temperature.  Defaults to comfortRange=1 if using Fahrenheit and comfortRange=.5 if using Celsius. Ignored if a targetSetpoint is included in the thermostat group.
   * `ThermostatController.lowerSetpoint`
     * Items that represent a lower or COOL set point for a thermostat, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
     * Supported item type:
@@ -277,7 +281,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
       * comfortRange=`<number>`
         * When dual setpoints (upper,lower) are used this is the amount under the requested temperature when requesting Alexa to set or adjust the current temperature.  Defaults to comfortRange=1 if using Fahrenheit and comfortRange=.5 if using Celsius.  Ignored if a targetSetpoint is included in the thermostat group.
   * `ThermostatController.thermostatMode`
-    * Items that represent the mode for a thermostat, default string values are "OFF=off,HEAT=heat,COOL=cool,ECO=eco,AUTO=auto", but these can be mapped to other values in the metadata. The mapping can be, in order of precedence, user-defined (AUTO=3,...) or preset-based related to the thermostat binding used (binding=`<value>`). If neither of these settings are provided, for thermostats that only support a subset of the standard modes, a comma delimited list of the Alexa supported modes should be set using the supportedModes parameter, otherwise, the supported list will be compiled based of the configured mapping.
+    * Items that represent the mode for a thermostat, default string values are "OFF=off,HEAT=heat,COOL=cool,ECO=eco,AUTO=auto", but these can be mapped to other values in the metadata. The mapping can be, in order of precedence, user-defined (AUTO=3,...) or preset-based related to the thermostat binding used (binding=`<value>`). For the binding parameter, it will be automatically determined if the associated item is using a 2.x addon (via channel metadata). If neither of these settings are provided, for thermostats that only support a subset of the standard modes, a comma delimited list of the Alexa supported modes should be set using the supportedModes parameter, otherwise, the supported list will be compiled based of the default mapping.
     * Supported item type:
       * Number
       * String
@@ -298,7 +302,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * [zwave1](https://www.openhab.org/addons/bindings/zwave1/) [OFF=0, HEAT=1, COOL=2, AUTO=3]
         * defaults to [OFF=off, HEAT=heat, COOL=cool, ECO=eco, AUTO=auto] if omitted
       * supportedModes=`<values>`
-        * defaults to, depending on the parameters provided, either user-based, preset-based or default mapping.
+        * defaults to, depending on the parameters provided, either user-based, preset-based or default item type-based mapping.
   * `TemperatureSensor.temperature`
     * Items that represent the current temperature, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
     * Supported item type:
@@ -310,7 +314,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * Fahrenheit
         * Kelvin
   * `LockController.lockState`
-    * Items that represent the state of a lock (ON lock, OFF unlock). When associated to an [item sensor](#item-sensor), the state of that item will be returned instead of the original actionable item. Additionally, when linking to such item, multiple properties to one state can be mapped with column delimiter (e.g. for a zwave lock: [LOCKED="1:3",UNLOCKED="2:4",JAMMED=11]).
+    * Items that represent the state of a lock (ON lock, OFF unlock). When associated to an [item sensor](#item-sensor), the state of that item will be returned instead of the original actionable item. Additionally, when linking to such item, multiple properties to one state can be mapped with column delimiter (e.g. for a Z-Wave lock: [LOCKED="1:3",UNLOCKED="2:4",JAMMED=11]).
     * Supported item type:
       * Switch
     * Supported sensor type:
@@ -396,6 +400,32 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
     * Supported item type:
       * Player
     * Default category: OTHER
+  * `EqualizerController.bands:{bass,midrange,treble}`
+    * Items that represent the different equalizer bands and their ranges supported by an audio system. Use specific capability component (`bass`, `midrange` or `treble`) when configuring a band (e.g. `EqualizerController.bands:bass`). Add the band range values in the `range="-10:10"` parameter. For the reset default value, provide the setting in `default=0` parameter or it will be calculated by using midpoint range spread. Additionally, default adjust increment can be configured in `increment=2` parameter. When configuring multiple bands, make sure to synchronize the range parameter across relevant items as the same range values will be used for all bands due to Alexa restriction. However, the reset and increment default values can be different between bands.
+    * Supported item type:
+      * Dimmer
+      * Number
+    * Default category: SPEAKER
+    * Supports additional properties:
+      * range=`<minValue:maxValue>`
+        * defaults to `[0:100]` for Dimmer and `[-10:10]` for Number item types if omitted
+      * default=`<number>`
+        * defaults to midpoint range spread if omitted
+      * increment=`<number>`
+        * defaults to increment=INCREASE/DECREASE (Dimmer) or increment=1 (Number) if omitted
+  * `EqualizerController.modes`
+    * Items that represent a list of equalizer modes supported by an audio system. Set supported modes using `supportedModes="MOVIE,MUSIC,TV"` parameter. The mode listed in additional properties are the only ones supported by the Alexa API currently. For the mapping, default item type mapping (listed below) can be used or if necessary, add each state to the parameters similar to how it is done with other interfaces.
+    * Supported item type:
+      * Number [MOVIE=1, MUSIC=2, NIGHT=3, SPORT=4, TV=5]
+      * String [MOVIE=movie, MUSIC=music, NIGHT=night, SPORT=sport, TV=tv]
+    * Default category: SPEAKER
+    * Supports additional properties:
+      * MOVIE=`<state>`
+      * MUSIC=`<state>`
+      * NIGHT=`<state>`
+      * SPORT=`<state>`
+      * supportedModes=`<modes>`
+        * defaults to, depending on the parameters provided, either user-based or default item type-based mapping.
   * `ContactSensor.detectionState`
     * Items that represent a contact sensor that can be used to trigger Alexa routines. (Currently not usable as proactive reporting not supported yet)
     * Supported item type:
@@ -434,7 +464,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * error state when system has open zones preventing arming
       * supportedArmStates=`<states>`
         * supported arm states should only be a list of DISARMED and ARMED_* states; do not put error states in that parameter.
-        * defaults to, depending on the parameters provided, either user-based or default item type mapping.
+        * defaults to, depending on the parameters provided, either user-based or default item type-based mapping.
       * supportsArmInstant=`<boolean>` (optional)
         * only supported with String item type and exitDelay parameter provided
         * defaults to false
@@ -519,7 +549,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * each name formatted as `<@assetIdOrName>`
         * defaults to item label name
 
-##### Item Categories
+##### Display Categories
   * Alexa has certain categories that effect how voice control and their mobile/web UI's display or control endpoints.  An example of this is when you create "Smart Device Groups" in the Alex app and associate a specific Echo or Dot to that Group (typically a room).  When a user asks to turn the lights ON, Alexa looks for devices in that group that have the category "LIGHT" to send the command to.  
   * You can override this default value on items by adding it as a parameter to the metadata, ex:
 
@@ -645,7 +675,7 @@ Weight.Ounces |
 * Child item categories are ignored and only the group category is used on items.
 * Case is ignored on the category part of the metadata and any value will be made all uppercase before its passed to the Alexa API.
 
-#### Label Support
+#### Supported Labels
 Item tags and metadata labels translate to a set of capabilities and can be used as a convenience to using the longer meta data format configuration.  These are the same as v2 tags but add additional functions and provide the ability to add customization through additional properties which take precedence over the default ones. Here are some examples:
 ```
 Switch OutletPlug "Outlet Plug" {alexa="Switchable" [category="SMARTPLUG"]}
@@ -763,9 +793,41 @@ String EntertainmentChannel "Entertainment Channel" {alexa="ChannelController.ch
 ```
 String EntertainmentInput "Entertainment Input" ["EntertainmentInput]
 
-String EntertainmentInput "Entertainment Input" {alexa="EntertainmentInput}
+String EntertainmentInput "Entertainment Input" {alexa="EntertainmentInput"}
 
 String EntertainmentInput "Entertainment Input" {alexa="InputController.input"}
+```
+* EqualizerBass
+```
+Number EqualizerBass "Equalizer Bass" ["EqualizerBass"]
+
+Number EqualizerBass "Equalizer Bass" {alexa="EqualizerBass"}
+
+Number EqualizerBass "Equalizer Bass" {alexa="EqualizerController.bands:bass}
+```
+* EqualizerMidrange
+```
+Number EqualizerMidrange "Equalizer Midrange" ["EqualizerMidrange"]
+
+Number EqualizerMidrange "Equalizer Midrange" {alexa="EqualizerMidrange"}
+
+Number EqualizerMidrange "Equalizer Midrange" {alexa="EqualizerController.bands:midrange"}
+```
+* EqualizerTreble
+```
+Number EqualizerTreble "Equalizer Treble" ["EqualizerTreble"]
+
+Number EqualizerTreble "Equalizer Treble" {alexa="EqualizerTreble"}
+
+Number EqualizerTreble "Equalizer Treble" {alexa="EqualizerController.bands:treble"}
+```
+* EqualizerMode
+```
+String EqualizerMode "Equalizer Mode" ["EqualizerMode"]
+
+String EqualizerMode "Equalizer Mode" {alexa="EqualizerMode"}
+
+String EqualizerMode "Equalizer Mode" {alexa="EqualizerController.modes"}
 ```
 * MediaPlayer
 ```

--- a/alexa/config.js
+++ b/alexa/config.js
@@ -22,8 +22,11 @@ module.exports = Object.freeze({
    *        {
    *          'name': <propertyName1>,
    *          'schema': <propertySchemaName1>,
-   *          'isReportable': <boolean>,
-   *          'multiInstance': <boolean>
+   *          'report': <propertyReportName1>,        (Use if report property name different than discovery one)
+   *          'components': [ <componentName1>, ... ] (Use if sub-property components are needed)
+   *          'isReportable': <boolean>,              (Include in context properties response)
+   *          'isSupported': <boolean>,               (Include in capabilities supported properties discovery response)
+   *          'multiInstance': <boolean>              (Support multi-instance)
    *        },
    *        ...
    *      ]
@@ -75,10 +78,17 @@ module.exports = Object.freeze({
         {'name': 'connectivity', 'schema': 'connectivity'}
       ]
     },
+    'EqualizerController': {
+      'category': 'SPEAKER',
+      'properties': [
+        {'name': 'bands', 'schema': 'equalizerBands', 'components': ['bass', 'midrange', 'treble']},
+        {'name': 'modes', 'schema': 'equalizerMode', 'report': 'mode'}
+      ]
+    },
     'InputController': {
       'category': 'TV',
       'properties': [
-        {'name': 'input', 'schema': 'inputs'}
+        {'name': 'input', 'schema': 'inputs', 'isSupported': false}
       ]
     },
     'LockController': {
@@ -108,7 +118,7 @@ module.exports = Object.freeze({
     'PlaybackController': {
       'category': 'OTHER',
       'properties': [
-        {'name': 'playbackState', 'schema': 'playbackState', 'isReportable': false}
+        {'name': 'playbackState', 'schema': 'playbackState', 'isReportable': false, 'isSupported': false}
       ]
     },
     'PowerController': {
@@ -132,7 +142,7 @@ module.exports = Object.freeze({
     'SceneController': {
       'category': 'SCENE_TRIGGER',
       'properties': [
-        {'name': 'scene', 'schema': 'scene', 'isReportable': false}
+        {'name': 'scene', 'schema': 'scene', 'isReportable': false, 'isSupported': false}
       ]
     },
     'SecurityPanelController': {
@@ -155,8 +165,8 @@ module.exports = Object.freeze({
     'StepSpeaker': {
       'category': 'SPEAKER',
       'properties': [
-        {'name': 'muted', 'schema': 'muteState', 'isReportable': false},
-        {'name': 'volume', 'schema': 'volumeLevel', 'isReportable': false}
+        {'name': 'muted', 'schema': 'muteState', 'isReportable': false, 'isSupported': false},
+        {'name': 'volume', 'schema': 'volumeLevel', 'isReportable': false, 'isSupported': false}
       ]
     },
     'TemperatureSensor' : {
@@ -287,6 +297,28 @@ module.exports = Object.freeze({
             'Switch':  {'NOT_DETECTED': 'OFF', 'DETECTED': 'ON'}
           }
         },
+        'type': 'string'
+      }
+    },
+    'equalizerBands': {
+      'itemTypes': ['Dimmer', 'Number'],
+      'state': {
+        'type': 'integer'
+      }
+    },
+    'equalizerMode': {
+      'itemTypes': ['Number', 'String'],
+      'state': {
+        'map': {
+          'default': {
+            'Number': {'MOVIE': '1', 'MUSIC': '2', 'NIGHT': '3', 'SPORT': '4', 'TV': '5'},
+            'String': {'MOVIE': 'movie', 'MUSIC': 'music', 'NIGHT': 'night', 'SPORT': 'sport', 'TV': 'tv'}
+          }
+        },
+        'supported': [
+          // https://developer.amazon.com/docs/device-apis/alexa-equalizercontroller.html#discovery
+          'MOVIE', 'MUSIC', 'NIGHT', 'SPORT', 'TV'
+        ],
         'type': 'string'
       }
     },
@@ -522,7 +554,7 @@ module.exports = Object.freeze({
    * Defines alexa capability namespace format pattern
    * @type {RegExp}
    */
-  CAPABILITY_PATTERN: /^(?:Alexa\.)?(\w+)\.(\w+)$/,
+  CAPABILITY_PATTERN: /^(?:Alexa\.)?(\w+)\.(\w+)[:]?(\w*)$/,
 
   /**
    * Defines alexa endpoint namespace format pattern

--- a/alexa/response.js
+++ b/alexa/response.js
@@ -64,8 +64,8 @@ class AlexaResponse {
     return Object.assign({
       namespace: parameters.namespace || 'Alexa',
       name: parameters.name || 'Response',
+      payloadVersion: this.directive.header.payloadVersion,
       messageId: uuid(),
-      payloadVersion: this.directive.header.payloadVersion
     }, this.directive.header.correlationToken && {
       // Include correlationToken property if provided in directive header
       correlationToken: this.directive.header.correlationToken

--- a/alexa/v3/channelController.js
+++ b/alexa/v3/channelController.js
@@ -37,10 +37,9 @@ class AlexaChannelController extends AlexaDirective {
     // Determine channel number using channel name if provided and defined in property parameters,
     //    otherwise use provided channel number
     const channelName = this.directive.payload.channelMetadata.name || '';
-    const channelIndex = Object.keys(properties.channel.parameters).findIndex(
+    const channelParam = Object.keys(properties.channel.parameters).find(
       name => name.toUpperCase() === channelName.toUpperCase())
-    const channelNumber = channelIndex !== -1 ?
-      Object.values(properties.channel.parameters)[channelIndex] : this.directive.payload.channel.number;
+    const channelNumber = properties.channel.parameters[channelParam] || this.directive.payload.channel.number;
     const postItem = Object.assign({}, properties.channel.item, {
       state: channelNumber
     });

--- a/alexa/v3/discovery.js
+++ b/alexa/v3/discovery.js
@@ -36,8 +36,7 @@ class AlexaDiscovery extends AlexaDirective {
       const discoveredDevices = [];
       const groupItems = [];
 
-      log.debug('Items:', items);
-      log.debug('Settings:', settings);
+      log.debug('Data:', {items: items, settings: settings});
 
       items.forEach((item) => {
         // Skip item if already part of a group
@@ -279,6 +278,18 @@ function convertV2Item(item, config = {}) {
           break;
         case 'EntertainmentInput':
           capabilities = ['InputController.input'];
+          break;
+        case 'EqualizerBass':
+          capabilities = ['EqualizerController.bands:bass'];
+           break;
+        case 'EqualizerMidrange':
+          capabilities = ['EqualizerController.bands:midrange'];
+          break;
+        case 'EqualizerTreble':
+          capabilities = ['EqualizerController.bands:treble'];
+          break;
+        case 'EqualizerMode':
+          capabilities = ['EqualizerController.modes'];
           break;
         case 'MediaPlayer':
           capabilities = ['PlaybackController.playback'];

--- a/alexa/v3/equalizerController.js
+++ b/alexa/v3/equalizerController.js
@@ -7,7 +7,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
+const log = require('@lib/log.js');
 const AlexaDirective = require('../directive.js');
+const { normalize } = require('../propertyState.js');
 
 /**
  * Defines Alexa.EqualizerController interface directive class
@@ -23,11 +25,77 @@ class AlexaEqualizerController extends AlexaDirective {
     super(directive, callback);
     this.interface = 'EqualizerController';
     this.map = {
-      setBands: undefined,
-      adjustBands: undefined,
-      resetBands: undefined,
-      setMode: undefined
+      setBands: 'setBands',
+      adjustBands: 'adjustBands',
+      resetBands: 'setBands',
+      setMode: 'setMode'
     };
+  }
+
+  /**
+   * Set bands
+   */
+  setBands() {
+    const properties = this.propertyMap.EqualizerController;
+    const bandLevel = this.directive.payload.bands.reduce((values, band) =>
+      Object.assign(values, {[`bands:${band.name.toLowerCase()}`]: band.level}), {});
+    const postItems = Object.keys(properties).reduce((items, propertyName) =>
+      items.concat(!bandLevel.hasOwnProperty(propertyName) ? [] :
+        Object.assign({}, properties[propertyName].item, {
+          state: bandLevel[propertyName] || properties[propertyName].parameters.default
+        })
+      ), []);
+    log.debug('setBands to values:', {item: postItems});
+    this.postItemsAndReturn(postItems);
+  }
+
+  /**
+   * Adjust bands
+   */
+  adjustBands() {
+    const properties = this.propertyMap.EqualizerController;
+    const bandLevelDelta = this.directive.payload.bands.reduce((values, band) =>
+      Object.assign(values, {[`bands:${band.name.toLowerCase()}`]:
+        (band.levelDirection === 'UP' ? 1 : -1) * band.levelDelta || band.levelDirection}), {});
+    const promises = Object.keys(properties).reduce((promises, propertyName) =>
+      promises.concat(!bandLevelDelta.hasOwnProperty(propertyName) ? [] :
+        this.getItemState(properties[propertyName].item).then((item) => {
+          const increment = parseInt(properties[propertyName].parameters.increment);
+          const minRange = properties[propertyName].parameters.range.minimum;
+          const maxRange = properties[propertyName].parameters.range.maximum;
+          let state;
+
+          // Set state to increase/decrease for dimmer if level delta not provided in request and increment not defined,
+          //  otherwise use either provided level delta, increment parameter or default delta of 1 to set adjusted state
+          if (isNaN(bandLevelDelta[propertyName]) && isNaN(increment) && item.type === 'Dimmer') {
+            state = bandLevelDelta[propertyName] === 'UP' ? 'INCREASE' : 'DECREASE';
+          } else {
+            state = parseInt(item.state) + (parseInt(bandLevelDelta[propertyName]) ||
+              (bandLevelDelta[propertyName] === 'UP' ? 1 : -1) * (increment || 1));
+            state = state < minRange ? minRange : state < maxRange ? state : maxRange;
+          }
+
+          return Object.assign({}, properties[propertyName].item, {state: state});
+        })
+      ), []);
+    Promise.all(promises).then((postItems) => {
+      log.debug('adjustBands to values:', {items: postItems});
+      this.postItemsAndReturn(postItems);
+    }).catch((error) => {
+      log.error('adjustBands failed with error:', error);
+      this.returnAlexaGenericErrorResponse();
+    });
+  }
+
+  /**
+   * Set mode
+   */
+  setMode() {
+    const properties = this.propertyMap.EqualizerController;
+    const postItem = Object.assign({}, properties.modes.item, {
+      state: normalize(properties.modes, this.directive.payload.mode)
+    });
+    this.postItemsAndReturn([postItem]);
   }
 }
 

--- a/alexa/v3/thermostatController.js
+++ b/alexa/v3/thermostatController.js
@@ -74,7 +74,7 @@ class AlexaThermostatController extends AlexaDirective {
       );
     }
 
-    log.debug('setTargetTemperature to values:', postItems);
+    log.debug('setTargetTemperature to values:', {items: postItems});
     this.postItemsAndReturn(postItems);
   }
 
@@ -102,7 +102,7 @@ class AlexaThermostatController extends AlexaDirective {
       ));
     });
     Promise.all(promises).then((postItems) => {
-      log.debug('adjustTargetTemperature to values:', postItems);
+      log.debug('adjustTargetTemperature to values:', {items: postItems});
       this.postItemsAndReturn(postItems);
     }).catch((error) => {
       log.error('adjustTargetTemperature failed with error:', error);

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -72,12 +72,12 @@ function getItem(token, itemName) {
 }
 
 /**
- * Returns all items recursively with alexa metadata
+ * Returns all items recursively with alexa, channel and synonyms metadata
  * @param  {String}   token
  * @return {Promise}
  */
 function getItemsRecursively(token) {
-  return getItemOrItems(token, null, {'metadata': 'alexa', 'recursive': true});
+  return getItemOrItems(token, null, {'metadata': 'alexa,channel,synonyms', 'recursive': true});
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "setup": "node-lambda setup",
     "run": "node-lambda run",
     "deploy": "node-lambda deploy",
-    "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha --use_strict --reporter spec test/*.js"
+    "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha"
   },
   "dependencies": {
     "camelcase": "^5.0.0",

--- a/test/common.js
+++ b/test/common.js
@@ -21,9 +21,8 @@ function generateDirectiveRequest (request) {
     'header': {
       'namespace': null,
       'name': null,
-      'messageId': 'message-id',
-      'correlationToken': 'correlation-token',
-      'payloadVersion': '3'
+      'payloadVersion': '3',
+      'messageId': 'message-id'
     },
     'endpoint': {
       'endpointId': null,
@@ -40,6 +39,10 @@ function generateDirectiveRequest (request) {
     'endpoint': Object.assign(template.endpoint, request.endpoint),
     'payload': Object.assign(template.payload, request.payload)
   };
+  // add header correlation token for request other than discovery
+  if (directive.header.namespace !== 'Alexa.Discovery') {
+    directive.header.correlationToken = 'correlation-token';
+  }
   // remove endpoint if no id defined
   if (directive.endpoint.endpointId === null) {
     // move endpoint scope to payload if defined

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter spec
+--slow 125
+--use_strict

--- a/test/schemas/alexa_smart_home_message_schema.json
+++ b/test/schemas/alexa_smart_home_message_schema.json
@@ -30,6 +30,14 @@
         "type": "string",
         "minLength": 1
       },
+      "armState": {
+        "enum": [
+          "ARMED_AWAY",
+          "ARMED_STAY",
+          "ARMED_NIGHT",
+          "DISARMED"
+        ]
+      },
       "temperature": {
         "type": "object",
         "required": [
@@ -50,6 +58,15 @@
           }
         }
       },
+      "thermostatMode": {
+        "enum": [
+          "AUTO",
+          "COOL",
+          "HEAT",
+          "ECO",
+          "OFF"
+        ]
+      },
       "channel": {
         "type": "object",
         "additionalProperties": false,
@@ -66,9 +83,86 @@
         },
         "minProperties": 1
       },
+      "equalizerBands": {
+        "enum": [
+          "BASS",
+          "MIDRANGE",
+          "TREBLE"
+        ]
+      },
+      "equalizerMode": {
+        "enum": [
+          "MOVIE",
+          "MUSIC",
+          "NIGHT",
+          "SPORT",
+          "TV"
+        ]
+      },
       "input": {
-        "type": "string",
-        "minLength": 1
+        "enum": [
+          "AUX 1",
+          "AUX 2",
+          "AUX 3",
+          "AUX 4",
+          "AUX 5",
+          "AUX 6",
+          "AUX 7",
+          "BLURAY",
+          "CABLE",
+          "CD",
+          "COAX 1",
+          "COAX 2",
+          "COMPOSITE 1",
+          "DVD",
+          "GAME",
+          "HD RADIO",
+          "HDMI 1",
+          "HDMI 2",
+          "HDMI 3",
+          "HDMI 4",
+          "HDMI 5",
+          "HDMI 6",
+          "HDMI 7",
+          "HDMI 8",
+          "HDMI 9",
+          "HDMI 10",
+          "HDMI ARC",
+          "INPUT 1",
+          "INPUT 2",
+          "INPUT 3",
+          "INPUT 4",
+          "INPUT 5",
+          "INPUT 6",
+          "INPUT 7",
+          "INPUT 8",
+          "INPUT 9",
+          "INPUT 10",
+          "IPOD",
+          "LINE 1",
+          "LINE 2",
+          "LINE 3",
+          "LINE 4",
+          "LINE 5",
+          "LINE 6",
+          "LINE 7",
+          "MEDIA PLAYER",
+          "OPTICAL 1",
+          "OPTICAL 2",
+          "PHONO",
+          "PLAYSTATION",
+          "PLAYSTATION 3",
+          "PLAYSTATION 4",
+          "SATELLITE",
+          "SMARTCAST",
+          "TUNER",
+          "TV",
+          "USB DAC",
+          "VIDEO 1",
+          "VIDEO 2",
+          "VIDEO 3",
+          "XBOX"
+        ]
       },
       "volume": {
         "type": "integer",
@@ -1364,14 +1458,7 @@
                   ]
                 },
                 "value": {
-                  "enum": [
-                    "HEAT",
-                    "COOL",
-                    "AUTO",
-                    "ECO",
-                    "OFF",
-                    "CUSTOM"
-                  ]
+                  "$ref": "#/definitions/common.properties/thermostatMode"
                 },
                 "timeOfSample": {
                   "$ref": "#/definitions/common.properties/timestamp"
@@ -1439,6 +1526,22 @@
                   },
                   "retrievable": {
                     "type": "boolean"
+                  }
+                }
+              },
+              "configuration": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "supportsScheduling": {
+                    "type": "boolean"
+                  },
+                  "supportedModes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "$ref": "#/definitions/common.properties/thermostatMode"
+                    }
                   }
                 }
               }
@@ -1675,7 +1778,8 @@
             "required": [
               "type",
               "interface",
-              "version"
+              "version",
+              "inputs"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1692,38 +1796,19 @@
               "version": {
                 "$ref": "#/definitions/common.properties/version"
               },
-              "properties": {
-                "type": "object",
-                "required": [
-                  "supported",
-                  "proactivelyReported",
-                  "retrievable"
-                ],
-                "additionalProperties": false,
-                "properties": {
-                  "supported": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "name"
-                      ],
-                      "additionalProperties": false,
-                      "properties": {
-                        "name": {
-                          "enum": [
-                            "input"
-                          ]
-                        }
-                      }
+              "inputs": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "$ref": "#/definitions/common.properties/input"
                     }
-                  },
-                  "proactivelyReported": {
-                    "type": "boolean"
-                  },
-                  "retrievable": {
-                    "type": "boolean"
                   }
                 }
               }
@@ -1854,6 +1939,32 @@
                     "type": "boolean"
                   }
                 }
+              }
+            }
+          }
+        },
+        "StepSpeaker": {
+          "capabilities": {
+            "type": "object",
+            "required": [
+              "type",
+              "interface",
+              "version"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "type": {
+                "enum": [
+                  "AlexaInterface"
+                ]
+              },
+              "interface": {
+                "enum": [
+                  "Alexa.StepSpeaker"
+                ]
+              },
+              "version": {
+                "$ref": "#/definitions/common.properties/version"
               }
             }
           }
@@ -2426,14 +2537,100 @@
           }
         },
         "EqualizerController": {
+          "bands": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.EqualizerController"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "bands"
+                  ]
+                },
+                "value": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "$ref": "#/definitions/common.properties/equalizerBands"
+                      },
+                      "value": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
+          "mode": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.EqualizerController"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "mode"
+                  ]
+                },
+                "value": {
+                  "$ref": "#/definitions/common.properties/equalizerMode"
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
           "capabilities": {
             "type": "object",
             "required": [
               "type",
               "interface",
-              "version"
+              "version",
+              "configurations"
             ],
-            "additionalProperties": true,
+            "additionalProperties": false,
             "properties": {
               "type": {
                 "enum": [
@@ -2447,11 +2644,113 @@
               },
               "version": {
                 "$ref": "#/definitions/common.properties/version"
+              },
+              "configurations": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "bands": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "supported": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "$ref": "#/definitions/common.properties/equalizerBands"
+                            }
+                          }
+                        }
+                      },
+                      "range": {
+                        "type": "object",
+                        "required": [
+                          "minimum",
+                          "maximum"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "minimum": {
+                            "type": "number"
+                          },
+                          "maximum": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "modes": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "supported": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "$ref": "#/definitions/common.properties/equalizerMode"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "properties": {
+                "type": "object",
+                "required": [
+                  "supported",
+                  "proactivelyReported",
+                  "retrievable"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "supported": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "enum": [
+                            "bands",
+                            "modes"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "proactivelyReported": {
+                    "type": "boolean"
+                  },
+                  "retrievable": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           }
         },
-        "MotionSensor": {
+        "PlaybackController": {
           "capabilities": {
             "type": "object",
             "required": [
@@ -2459,7 +2758,86 @@
               "interface",
               "version"
             ],
-            "additionalProperties": true,
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "enum": [
+                  "AlexaInterface"
+                ]
+              },
+              "interface": {
+                "enum": [
+                  "Alexa.PlaybackController"
+                ]
+              },
+              "version": {
+                "$ref": "#/definitions/common.properties/version"
+              },
+              "supportedOperations": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "enum": [
+                    "Play",
+                    "Pause",
+                    "Stop",
+                    "StartOver",
+                    "Previous",
+                    "Next",
+                    "Rewind",
+                    "FastForward"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "MotionSensor": {
+          "detectionState": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.MotionSensor"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "detectionState"
+                  ]
+                },
+                "value": {
+                  "enum": [
+                    "DETECTED",
+                    "NOT_DETECTED"
+                  ]
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "required": [
+              "type",
+              "interface",
+              "version"
+            ],
+            "additionalProperties": false,
             "properties": {
               "type": {
                 "enum": [
@@ -2473,11 +2851,83 @@
               },
               "version": {
                 "$ref": "#/definitions/common.properties/version"
+              },
+              "properties": {
+                "type": "object",
+                "required": [
+                  "supported",
+                  "proactivelyReported",
+                  "retrievable"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "supported": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "enum": [
+                            "detectionState"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "proactivelyReported": {
+                    "type": "boolean"
+                  },
+                  "retrievable": {
+                    "type": "boolean"
+                  }
+                }
               }
             }
           }
         },
         "ContactSensor": {
+          "detectionState": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.ContactSensor"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "detectionState"
+                  ]
+                },
+                "value": {
+                  "enum": [
+                    "DETECTED",
+                    "NOT_DETECTED"
+                  ]
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
           "capabilities": {
             "type": "object",
             "required": [
@@ -2485,7 +2935,7 @@
               "interface",
               "version"
             ],
-            "additionalProperties": true,
+            "additionalProperties": false,
             "properties": {
               "type": {
                 "enum": [
@@ -2499,6 +2949,224 @@
               },
               "version": {
                 "$ref": "#/definitions/common.properties/version"
+              },
+              "properties": {
+                "type": "object",
+                "required": [
+                  "supported",
+                  "proactivelyReported",
+                  "retrievable"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "supported": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "enum": [
+                            "detectionState"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "proactivelyReported": {
+                    "type": "boolean"
+                  },
+                  "retrievable": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "SecurityPanelController": {
+          "alarmState": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.SecurityPanelController"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "burglaryAlarm",
+                    "fireAlarm",
+                    "carbonMonoxideAlarm",
+                    "waterAlarm"
+                  ]
+                },
+                "value": {
+                  "enum": [
+                    "OK",
+                    "ALARM"
+                  ]
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
+          "armState": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.SecurityPanelController"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "armState"
+                  ]
+                },
+                "value": {
+                  "$ref": "#/definitions/common.properties/armState"
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "required": [
+              "type",
+              "interface",
+              "version",
+              "configuration"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "enum": [
+                  "AlexaInterface"
+                ]
+              },
+              "interface": {
+                "enum": [
+                  "Alexa.SecurityPanelController"
+                ]
+              },
+              "version": {
+                "$ref": "#/definitions/common.properties/version"
+              },
+              "properties": {
+                "type": "object",
+                "required": [
+                  "supported",
+                  "proactivelyReported",
+                  "retrievable"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "supported": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "enum": [
+                            "armState",
+                            "burglaryAlarm",
+                            "fireAlarm",
+                            "carbonMonoxideAlarm",
+                            "waterAlarm"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "proactivelyReported": {
+                    "type": "boolean"
+                  },
+                  "retrievable": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "configuration": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "supportedAuthorizationTypes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "FOUR_DIGIT_PIN"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "supportsArmInstant": {
+                    "type": "boolean"
+                  },
+                  "supportedArmStates": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "value"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "value": {
+                          "$ref": "#/definitions/common.properties/armState"
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -2563,6 +3231,24 @@
             },
             {
               "$ref": "#/definitions/common.properties/interfaces/ModeController/mode/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/EqualizerController/bands/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/EqualizerController/mode/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/MotionSensor/detectionState/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/ContactSensor/detectionState/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/SecurityPanelController/alarmState/property"
+            },
+            {
+              "$ref": "#/definitions/common.properties/interfaces/SecurityPanelController/armState/property"
             }
           ]
         }
@@ -2608,6 +3294,17 @@
             },
             "timestamp": {
               "$ref": "#/definitions/common.properties/timestamp"
+            }
+          }
+        },
+        "securityPanelArm": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "exitDelayInSeconds": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
             }
           }
         }
@@ -2661,6 +3358,35 @@
           "namespace": {
             "enum": [
               "Alexa.ThermostatController"
+            ]
+          },
+          "name": {
+            "$ref": "#/definitions/ErrorResponse.properties/name"
+          },
+          "payloadVersion": {
+            "$ref": "#/definitions/common.properties/payloadVersion"
+          },
+          "messageId": {
+            "$ref": "#/definitions/common.properties/messageId"
+          },
+          "correlationToken": {
+            "$ref": "#/definitions/common.properties/correlationToken"
+          }
+        }
+      },
+      "header.SecurityPanelController": {
+        "type": "object",
+        "required": [
+          "namespace",
+          "name",
+          "payloadVersion",
+          "messageId"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "namespace": {
+            "enum": [
+              "Alexa.SecurityPanelController"
             ]
           },
           "name": {
@@ -2903,6 +3629,50 @@
             "$ref": "#/definitions/common.properties/temperature"
           }
         }
+      },
+      "payload.SecurityPanelController.general": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": [
+              "AUTHORIZATION_REQUIRED",
+              "BYPASS_NEEDED",
+              "NOT_READY",
+              "UNAUTHORIZED",
+              "UNCLEARED_ALARM",
+              "UNCLEARED_TROUBLE"
+            ]
+          },
+          "message": {
+            "$ref": "#/definitions/common.properties/message"
+          }
+        }
+      },
+      "payload.ColorTemperatureController.NOT_SUPPORTED_IN_CURRENT_MODE": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "enum": [
+              "NOT_SUPPORTED_IN_CURRENT_MODE"
+            ]
+          },
+          "message": {
+            "$ref": "#/definitions/common.properties/message"
+          },
+          "currentDeviceMode": {
+            "enum": [
+              "COLOR"
+            ]
+          }
+        }
       }
     },
     "ResponseOrStateReport.properties": {
@@ -2912,7 +3682,8 @@
           "StateReport",
           "ActivationStarted",
           "DeactivationStarted",
-          "AcceptGrant.Response"
+          "AcceptGrant.Response",
+          "Arm.Response"
         ]
       },
       "with.payload": {
@@ -2946,7 +3717,8 @@
                   "namespace": {
                     "enum": [
                       "Alexa.CameraStreamController",
-                      "Alexa.SceneController"
+                      "Alexa.SceneController",
+                      "Alexa.SecurityPanelController"
                     ]
                   },
                   "name": {
@@ -2973,6 +3745,9 @@
                   },
                   {
                     "$ref": "#/definitions/common.properties/payload/sceneActivationDeactivation"
+                  },
+                  {
+                    "$ref": "#/definitions/common.properties/payload/securityPanelArm"
                   }
                 ],
                 "minProperties": 1
@@ -3012,7 +3787,8 @@
                   "namespace": {
                     "enum": [
                       "Alexa",
-                      "Alexa.Authorization"
+                      "Alexa.Authorization",
+                      "Alexa.SecurityPanelController"
                     ]
                   },
                   "name": {
@@ -3180,6 +3956,34 @@
                 },
                 "payload": {
                   "$ref": "#/definitions/ErrorResponse.properties/payload.ThermostatController.REQUESTED_SETPOINTS_TOO_CLOSE"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "header": {
+                  "$ref": "#/definitions/ErrorResponse.properties/header.SecurityPanelController"
+                },
+                "endpoint": {
+                  "$ref": "#/definitions/common.properties/endpoint"
+                },
+                "payload": {
+                  "$ref": "#/definitions/ErrorResponse.properties/payload.SecurityPanelController.general"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "header": {
+                  "$ref": "#/definitions/ErrorResponse.properties/header.ColorTemperatureController"
+                },
+                "endpoint": {
+                  "$ref": "#/definitions/common.properties/endpoint"
+                },
+                "payload": {
+                  "$ref": "#/definitions/ErrorResponse.properties/payload.ColorTemperatureController.NOT_SUPPORTED_IN_CURRENT_MODE"
                 }
               }
             },
@@ -3452,6 +4256,7 @@
                             "SMARTLOCK",
                             "SCENE_TRIGGER",
                             "ACTIVITY_TRIGGER",
+                            "SECURITY_PANEL",
                             "OTHER"
                           ]
                         }
@@ -3515,6 +4320,9 @@
                               "$ref": "#/definitions/common.properties/interfaces/Speaker/capabilities"
                             },
                             {
+                              "$ref": "#/definitions/common.properties/interfaces/StepSpeaker/capabilities"
+                            },
+                            {
                               "$ref": "#/definitions/common.properties/interfaces/SceneController/capabilities"
                             },
                             {
@@ -3542,10 +4350,16 @@
                               "$ref": "#/definitions/common.properties/interfaces/EqualizerController/capabilities"
                             },
                             {
+                              "$ref": "#/definitions/common.properties/interfaces/PlaybackController/capabilities"
+                            },
+                            {
                               "$ref": "#/definitions/common.properties/interfaces/ContactSensor/capabilities"
                             },
                             {
                               "$ref": "#/definitions/common.properties/interfaces/MotionSensor/capabilities"
+                            },
+                            {
+                              "$ref": "#/definitions/common.properties/interfaces/SecurityPanelController/capabilities"
                             }
                           ]
                         }

--- a/test/settings.js
+++ b/test/settings.js
@@ -60,6 +60,9 @@ var settings = {
       "ContactSensor": [
         "./v3/test_controllerContactSensor.js"
       ],
+      "EqualizerController": [
+        "./v3/test_controllerEqualizer.js"
+      ],
       "InputController": [
         "./v3/test_controllerInput.js"
       ],

--- a/test/test_ohConnectorV3.js
+++ b/test/test_ohConnectorV3.js
@@ -81,6 +81,7 @@ describe('ohConnectorV3 Tests', function () {
           setTimeout(function () {
             // console.log('Capture:', JSON.stringify(capture, null, 2));
             assert.discoveredEndpoints(capture.result.event.payload.endpoints, test.expected);
+            assert.validSchema(capture.result, test.validate);
             done();
           }, 1);
         });

--- a/test/v3/test_controllerColorTemperature.js
+++ b/test/v3/test_controllerColorTemperature.js
@@ -225,7 +225,6 @@ module.exports = [
         }
       },
       openhab: []
-    },
-    validate: false
+    }
   }
 ];

--- a/test/v3/test_controllerContactSensor.js
+++ b/test/v3/test_controllerContactSensor.js
@@ -40,7 +40,6 @@ module.exports = [
         }
       },
       openhab: []
-    },
-    validate: false
+    }
   }
 ];

--- a/test/v3/test_controllerEqualizer.js
+++ b/test/v3/test_controllerEqualizer.js
@@ -1,0 +1,353 @@
+module.exports = [
+  {
+    description: "set bands",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "SetBands"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "bands:bass": {
+                "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+                "item": {"name": "equalizerBass", "type": "Number"}, "schema": {"name": "equalizerBands"}
+              },
+              "bands:treble": {
+                "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+                "item": {"name": "equalizerTreble", "type": "Number"}, "schema": {"name": "equalizerBands"}
+              },
+              "modes": {
+                "parameters": {"supportedModes": ["MOVIE", "TV"]},
+                "item": {"name": "equalizerMode", "type": "String"}, "schema": {"name": "equalizerMode"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "bands": [
+          {"name": "BASS", "level": -2}
+        ]
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "equalizerBass", "state": "-2", "type": "Number"},
+        {"name": "equalizerTreble", "state": "2", "type": "Number"},
+        {"name": "equalizerMode", "state": "movie", "type": "String"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [
+            {
+              "namespace": "Alexa.EqualizerController",
+              "name": "bands",
+              "value": [
+                {
+                  "name": "BASS",
+                  "value": -2
+                },
+                {
+                  "name": "TREBLE",
+                  "value": 2
+                }
+              ]
+            },
+            {
+              "namespace": "Alexa.EqualizerController",
+              "name": "mode",
+              "value": "MOVIE"
+            }
+          ]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerBass", "value": -2}
+      ]
+    }
+  },
+  {
+    description: "adjust bands with level delta",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "AdjustBands"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "bands:bass": {
+                "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+                "item": {"name": "equalizerBass", "type": "Number"}, "schema": {"name": "equalizerBands"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "bands": [
+          {"name": "BASS", "levelDelta": 7, "levelDirection": "DOWN"}
+        ]
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "equalizerBass", "state": "1", "type": "Number"},
+        {"name": "equalizerBass", "state": "-5", "type": "Number"},
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.EqualizerController",
+            "name": "bands",
+            "value": [{
+              "name": "BASS",
+              "value": -5
+            }]
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerBass", "value": -5}
+      ]
+    }
+  },
+  {
+    description: "adjust bands no level delta number item",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "AdjustBands"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "bands:bass": {
+                "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0, "increment": 3},
+                "item": {"name": "equalizerBass", "type": "Number"}, "schema": {"name": "equalizerBands"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "bands": [
+          {"name": "BASS", "levelDirection": "DOWN"}
+        ]
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "equalizerBass", "state": "1", "type": "Number"},
+        {"name": "equalizerBass", "state": "-2", "type": "Number"},
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.EqualizerController",
+            "name": "bands",
+            "value": [{
+              "name": "BASS",
+              "value": -2
+            }]
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerBass", "value": -2}
+      ]
+    }
+  },
+  {
+    description: "adjust bands no level delta dimmer item",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "AdjustBands"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "bands:bass": {
+                "parameters": {"range": {"minimum": 0, "maximum": 100}, "default": 50},
+                "item": {"name": "equalizerBass", "type": "Dimmer"}, "schema": {"name": "equalizerBands"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "bands": [
+          {"name": "BASS", "levelDirection": "UP"}
+        ]
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "equalizerBass", "state": "50", "type": "Dimmer"},
+        {"name": "equalizerBass", "state": "60", "type": "Dimmer"},
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.EqualizerController",
+            "name": "bands",
+            "value": [{
+              "name": "BASS",
+              "value": 60
+            }]
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerBass", "value": 'INCREASE'}
+      ]
+    }
+  },
+  {
+    description: "reset bands",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "ResetBands"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "bands:bass": {
+                "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+                "item": {"name": "equalizerBass", "type": "Number"}, "schema": {"name": "equalizerBands"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "bands": [
+          {"name": "BASS"}
+        ]
+      }
+    },
+    mocked: {
+      openhab: {"name": "equalizerBass", "state": "0", "type": "Number"}
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.EqualizerController",
+            "name": "bands",
+            "value": [{
+              "name": "BASS",
+              "value": 0
+            }]
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerBass", "value": 0}
+      ]
+    }
+  },
+  {
+    description: "set mode",
+    directive: {
+      "header": {
+        "namespace": "Alexa.EqualizerController",
+        "name": "SetMode"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "EqualizerController": {
+              "modes": {
+                "parameters": {"supportedModes": ["MOVIE", "TV"]},
+                "item": {"name": "equalizerMode", "type": "String"}, "schema": {"name": "equalizerMode"}
+              }
+            }
+          })
+        }
+      },
+      "payload": {
+        "mode": "MOVIE"
+      }
+    },
+    mocked: {
+      openhab: {"name": "equalizerMode", "state": "movie", "type": "String"}
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [{
+            "namespace": "Alexa.EqualizerController",
+            "name": "mode",
+            "value": "MOVIE"
+          }]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          },
+        }
+      },
+      openhab: [
+        {"name": "equalizerMode", "value": "movie"}
+      ]
+    }
+  }
+];

--- a/test/v3/test_controllerMotionSensor.js
+++ b/test/v3/test_controllerMotionSensor.js
@@ -40,7 +40,6 @@ module.exports = [
         }
       },
       openhab: []
-    },
-    validate: false
+    }
   }
 ];

--- a/test/v3/test_controllerSecurityPanel.js
+++ b/test/v3/test_controllerSecurityPanel.js
@@ -62,8 +62,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": "away:instant"}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "arm away delay string item",
@@ -122,8 +121,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": "away"}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "arm stay no delay number item",
@@ -179,8 +177,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": 1}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "arm authorization required error",
@@ -227,8 +224,7 @@ module.exports = [
         }
       },
       openhab: []
-    },
-    validate: false
+    }
   },
   {
     description: "disarm with pin code",
@@ -291,8 +287,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": "disarm:1234"}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "disarm no pin code",
@@ -341,8 +336,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": "disarm"}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "disarm unauthorized error",
@@ -393,8 +387,7 @@ module.exports = [
       openhab: [
         {"name": "AlarmMode", "value": "disarm:1234"}
       ]
-    },
-    validate: false
+    }
   },
   {
     description: "alarm state report",
@@ -488,7 +481,6 @@ module.exports = [
         }
       },
       openhab: []
-    },
-    validate: false
+    }
   }
 ];

--- a/test/v3/test_discoverFan.js
+++ b/test/v3/test_discoverFan.js
@@ -48,6 +48,9 @@ module.exports = {
               "config": {
                 "supportedRange": "0:120:20"
               }
+            },
+            "synonyms": {
+              "value": "Fan Angle,Orientation"
             }
           },
           "groupNames": ["gTowerFan"]
@@ -79,7 +82,7 @@ module.exports = {
       "friendlyName": "Tower Fan",
       "resources": {
         "Alexa.RangeController.TowerFanAngle": {
-          "friendlyNames": ["text:Fan Angle:en-US"]
+          "friendlyNames": ["text:Fan Angle:en-US", "text:Orientation:en-US"]
         },
         "Alexa.RangeController.TowerFanSpeed": {
           "friendlyNames": ["asset:Alexa.Setting.FanSpeed", "text:Air Speed:en-US", "text:Speed:en-US"]
@@ -111,7 +114,7 @@ module.exports = {
             "parameters": {
               "supportedRange": {"minimumValue": 0, "maximumValue": 120, "precision": 20},
               "unitOfMeasure": "Angle.Degrees",
-              "friendlyNames": ["Fan Angle"]
+              "friendlyNames": ["Fan Angle", "Orientation"]
             },
             "item": {"name": "TowerFanAngle", "type": "Number:Angle"},
             "schema": {"name": "rangeValue"}

--- a/test/v3/test_discoverSpeaker.js
+++ b/test/v3/test_discoverSpeaker.js
@@ -38,6 +38,81 @@ module.exports = {
             }
           },
           "groupNames": ["gSpeaker"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/equalizerBass",
+          "type": "Number",
+          "name": "equalizerBass",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "EqualizerController.bands:bass",
+              "config": {
+                "range": "-5:5"
+              }
+            }
+          },
+          "groupNames": ["gSpeaker"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/equalizerMidrange",
+          "type": "Number",
+          "name": "equalizerMidrange",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "EqualizerController.bands:midrange",
+              "config": {
+                "range": "-5:5"
+              }
+            }
+          },
+          "groupNames": ["gSpeaker"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/equalizerTreble",
+          "type": "Number",
+          "name": "equalizerTreble",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "EqualizerController.bands:treble",
+              "config": {
+                "range": "-5:5"
+              }
+            }
+          },
+          "groupNames": ["gSpeaker"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/equalizerInvalid",
+          "type": "Number",
+          "name": "equalizerInvalid",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "EqualizerController.bands:invalid",
+              "config": {
+                "range": "-5:5"
+              }
+            }
+          },
+          "groupNames": ["gSpeaker"]
+        },
+        {
+          "link": "https://myopenhab.org/rest/items/equalizerMode",
+          "type": "String",
+          "name": "equalizerMode",
+          "tags": [],
+          "metadata": {
+            "alexa": {
+              "value": "EqualizerController.modes",
+              "config": {
+                "supportedModes": "MOVIE,TV,FOOBAR"
+              }
+            }
+          },
+          "groupNames": ["gSpeaker"]
         }
       ],
       "link": "https://myopenhab.org/rest/items/gSpeaker",
@@ -57,13 +132,50 @@ module.exports = {
     "gSpeaker": {
       "capabilities": [
         "Alexa",
-        "Alexa.Speaker.volume",
         "Alexa.Speaker.muted",
+        "Alexa.Speaker.volume",
         "Alexa.PlaybackController",
+        "Alexa.EqualizerController.bands",
+        "Alexa.EqualizerController.modes",
         "Alexa.EndpointHealth.connectivity"
       ],
       "displayCategories": ["SPEAKER"],
-      "friendlyName": "Speaker"
+      "friendlyName": "Speaker",
+      "parameters": {
+        "Alexa.EqualizerController.configurations": {
+          "bands": {
+            "supported": [{"name": "BASS"}, {"name": "MIDRANGE"}, {"name": "TREBLE"}],
+            "range": {"minimum": -5, "maximum": 5}
+          },
+          "modes": {
+            "supported": [{"name": "MOVIE"}, {"name": "TV"}]
+          }
+        }
+      },
+      "propertyMap": {
+        "EqualizerController": {
+          "bands:bass": {
+            "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+            "item": {"name": "equalizerBass", "type": "Number"},
+            "schema": {"name": "equalizerBands"}
+          },
+          "bands:midrange": {
+            "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+            "item": {"name": "equalizerMidrange", "type": "Number"},
+            "schema": {"name": "equalizerBands"}
+          },
+          "bands:treble": {
+            "parameters": {"range": {"minimum": -5, "maximum": 5}, "default": 0},
+            "item": {"name": "equalizerTreble", "type": "Number"},
+            "schema": {"name": "equalizerBands"}
+          },
+          "modes": {
+            "parameters": {"supportedModes": ["MOVIE", "TV"]},
+            "item": {"name": "equalizerMode", "type": "String"},
+            "schema": {"name": "equalizerMode"}
+          }
+        }
+      }
     }
   }
 };

--- a/test/v3/test_discoverStepSpeaker.js
+++ b/test/v3/test_discoverStepSpeaker.js
@@ -45,8 +45,7 @@ module.exports = {
     "gStepSpeaker": {
       "capabilities": [
         "Alexa",
-        "Alexa.StepSpeaker.muted",
-        "Alexa.StepSpeaker.volume",
+        "Alexa.StepSpeaker",
         "Alexa.EndpointHealth.connectivity"
       ],
       "displayCategories": ["SPEAKER"],

--- a/test/v3/test_discoverThermostat.js
+++ b/test/v3/test_discoverThermostat.js
@@ -118,9 +118,11 @@ module.exports = {
               "value": "ThermostatController.thermostatMode",
               "config": {
                 "OFF": "off",
-                "HEAT": "heat",
-                "binding": "foobar"
+                "HEAT": "heat"
               }
+            },
+            "channel": {
+              "value": "foobar:thermostat:mode"
             }
           },
           "groupNames": ["gThermostat2"]


### PR DESCRIPTION
Fixes: #161
Fixes: #165

**Changes**
* Added ability to configure sub-property components to accommodate new capability
* Added ability to report a property under a different name than the one defined in discovery
* Added logic to determine thermostat binding 2.x parameter based on item channel metadata
* Added logic to determine mode range toggle friendly names based on item synonyms metadata
* Fixed log array object representation issue due to winston limitation
* Fixed discovery test directive request incorrectly including header correlation token
* Added schema validation to discovery test cases
* Updated validation json schema
* Moved mocha options into standard config file