### PR TITLE
Fix StepSpeaker to pass step value to openhab

### DIFF
--- a/lambda/smarthome/alexa/v3/stepSpeaker.js
+++ b/lambda/smarthome/alexa/v3/stepSpeaker.js
@@ -7,7 +7,6 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 
-const log = require('@lib/log.js');
 const AlexaDirective = require('../directive.js');
 
 /**
@@ -33,20 +32,10 @@ class AlexaStepSpeaker extends AlexaDirective {
    * Adjust volume
    */
   adjustVolume() {
-    const postItem = Object.assign({}, this.propertyMap.StepSpeaker.volume.item);
-
-    this.getItemState(postItem).then((item) => {
-      // Throw error if state not a number
-      if (isNaN(item.state)) {
-        throw {cause: 'Could not get numeric item state', item: item};
-      }
-
-      postItem.state = parseInt(item.state) + this.directive.payload.volumeSteps;
-      this.postItemsAndReturn([postItem]);
-    }).catch((error) => {
-      log.error('adjustVolume failed with error:', error);
-      this.returnAlexaGenericErrorResponse(error);
+    const postItem = Object.assign({}, this.propertyMap.StepSpeaker.volume.item, {
+      state: this.directive.payload.volumeSteps
     });
+    this.postItemsAndReturn([postItem]);
   }
 
   /**

--- a/lambda/smarthome/test/v3/test_controllerStepSpeaker.js
+++ b/lambda/smarthome/test/v3/test_controllerStepSpeaker.js
@@ -11,7 +11,7 @@ module.exports = [
         "cookie": {
           "propertyMap": JSON.stringify({
             "StepSpeaker": {
-              "volume": {"parameters": {}, "item": {"name": "stepSpeakerVolume"}, "schema": {"name": "volumeLevel"}}}
+              "volume": {"parameters": {}, "item": {"name": "stepSpeakerVolumeStep"}, "schema": {"name": "volumeLevel"}}}
           })
         }
       },
@@ -21,7 +21,6 @@ module.exports = [
     },
     mocked: {
       openhab: [
-        {"name": "stepSpeakerVolume", "state": "40", "type": "Dimmer"},
         {"name": "stepSpeakerVolume", "state": "50", "type": "Dimmer"}
       ],
       staged: true
@@ -39,7 +38,7 @@ module.exports = [
         }
       },
       openhab: [
-        {"name": "stepSpeakerVolume", "value": 50}
+        {"name": "stepSpeakerVolumeStep", "value": 10}
       ]
     }
   },


### PR DESCRIPTION
The documentation for the Alexa.StepSpeaker Interface says:

[...] implement this interface for devices that make incremental discrete step adjustments to volume, where the range of volume isn't known. For example, StepSpeaker can adjust volume by a step of 5, but can't adjust the volume to 50 percent. If your device can set the volume based on any continuous value in a range, implement the Speaker interface instead. [...]

I think that the StepSpeaker interface is meant for simple remote control like devices that do not have a volume state but only support "3 steps up" or "2 steps down" directives. Therefore I changed the adjustVolume function in stepSpeaker.js to only pass the incremental value to the device instead of modifying the state of the device (since the device does not have a state). What do you think?

Signed-off-by: Frank Meies <19324766+fmeies@users.noreply.github.com>