### PR TITLE
Set skill distribution mode based on deploy environment

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -9,7 +9,7 @@
       },
       "distributionCountries": [],
       "isAvailableWorldwide": true,
-      "distributionMode": "PUBLIC",
+      "distributionMode": "PRIVATE",
       "testingInstructions": "A demo account has been setup on our cloud service myopenhab.org for this skill:\n\nuser: %TESTING_USER:demo@openhab.org%\npass: %TESTING_PASS%\n\nOnce the skill is linked to our cloud service and discovery is run it should find a few lights as well as a thermostat.",
       "category": "SMART_HOME"
     },

--- a/tools/updateSkillManifest.js
+++ b/tools/updateSkillManifest.js
@@ -86,6 +86,18 @@ function setApiRegionalEndpoints(schema) {
 }
 
 /**
+ * Set publishing distribution settings (for production deployment)
+ * @param {Object} schema
+ */
+function setPublishingDistributionSettings(schema) {
+  if (process.env.ASK_ENV === 'production') {
+    schema.manifest.publishingInformation.distributionMode = 'PUBLIC';
+  } else {
+    schema.manifest.publishingInformation.distributionMode = 'PRIVATE';
+  }
+}
+
+/**
  * Format skill schema
  * @param {Object} schema
  */
@@ -136,6 +148,8 @@ if (require.main === module) {
     loadLocaleResources(schema);
     // Set api regional endpoints
     setApiRegionalEndpoints(schema);
+    // Set publishing distribution settings
+    setPublishingDistributionSettings(schema);
     // Format skill schema
     formatSkillSchema(schema);
     // Save skill schema


### PR DESCRIPTION
Only use public distribution mode for production deployment, otherwise set it as private by default.

```
ASK_ENV=production ask deploy
```