### PR TITLE
Add PlaybackStateReporter interface support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -165,7 +165,7 @@ Switch Mute     "Mute"    (Stereo)  {alexa="Speaker.muted"}
 Switch Power    "Power"   (Stereo)  {alexa="PowerController.powerState"}
 String Input    "Input"   (Stereo)  {alexa="InputController.input" [supportedInputs="HDMI1,TV"]}
 String Channel  "Channel" (Stereo)  {alexa="ChannelController.channel"}
-Player Player   "Player"  (Stereo)  {alexa="PlaybackController.playbackState"}
+Player Player   "Player"  (Stereo)  {alexa="PlaybackController.playback,PlaybackStateReporter.playbackState"}
 Number Bass     "Bass"    (Stereo)  {alexa="EqualizerController.bands:bass" [range="-10:10"]}
 Number Midrange "Mid"     (Stereo)  {alexa="EqualizerController.bands:midrange" [range="-10:10"]}
 Number Treble   "Treble"  (Stereo)  {alexa="EqualizerController.bands:treble" [range="-10:10"]}
@@ -394,11 +394,16 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
     * Supported item type:
       * Switch
     * Default category: SPEAKER
-  * `PlaybackController.playbackState`
-    * Items that represent the playback of a AV device. (Supported commands: Play, Pause, Next, Previous, Rewind, Fast Forward)
+  * `PlaybackController.playback`
+    * Items that represent the playback controls of a AV device. (Supported commands: Play, Pause, Next, Previous, Rewind, Fast Forward)
     * Supported item type:
       * Player
     * Default category: OTHER
+  * `PlaybackStateReporter.playbackState`
+    * Items that represent the playback state of a AV device. It should be used in combination with `PlaybackController.playback` to provide state back to Alexa.
+    * Supported item type:
+      * Player
+    * Default category: OTHER  
   * `EqualizerController.bands:{bass,midrange,treble}`
     * Items that represent the different equalizer bands and their ranges supported by an audio system. Use specific capability component (`bass`, `midrange` or `treble`) when configuring a band (e.g. `EqualizerController.bands:bass`). Add the band range values in the `range="-10:10"` parameter. For the reset default value, provide the setting in `default=0` parameter or it will be calculated by using midpoint range spread. Additionally, default adjust increment can be configured in `increment=2` parameter. When configuring multiple bands, make sure to synchronize the range parameter across relevant items as the same range values will be used for all bands due to Alexa restriction. However, the reset and increment default values can be different between bands.
     * Supported item type:
@@ -793,7 +798,7 @@ String EqualizerMode "Equalizer Mode" {alexa="EqualizerController.modes"}
 ```
 Player MediaPlayer "Media Player" ["MediaPlayer"]
 
-Player MediaPlayer "Media Player" {alexa="PlaybackController.playbackState"}
+Player MediaPlayer "Media Player" {alexa="PlaybackController.playback,PlaybackStateReporter.playbackState"}
 ```
 * SpeakerMute
 ```

--- a/lambda/smarthome/alexa/capabilities.js
+++ b/lambda/smarthome/alexa/capabilities.js
@@ -101,7 +101,7 @@ function getCapabilityInterface(interfaceName, properties, globalSettings = {}) 
       case 'inputs':
         capability.inputs = parameters.supportedInputs.map(input => Object.assign({name: input}));
         break;
-      case 'playbackState':
+      case 'playbackCommand':
         capability.supportedOperations = ['Play', 'Pause', 'Next', 'Previous', 'Rewind', 'FastForward'];
         break;
       case 'scene':

--- a/lambda/smarthome/alexa/config.js
+++ b/lambda/smarthome/alexa/config.js
@@ -118,7 +118,13 @@ module.exports = Object.freeze({
     'PlaybackController': {
       'category': 'OTHER',
       'properties': [
-        {'name': 'playbackState', 'schema': 'playbackState', 'isReportable': false, 'isSupported': false}
+        {'name': 'playback', 'schema': 'playbackCommand', 'isReportable': false, 'isSupported': false}
+      ]
+    },
+    'PlaybackStateReporter': {
+      'category': 'OTHER',
+      'properties': [
+        {'name': 'playbackState', 'schema': 'playbackState'}
       ]
     },
     'PowerController': {
@@ -285,7 +291,7 @@ module.exports = Object.freeze({
     },
     'connectivity': {
       'state': {
-        'type': 'string'
+        'type': 'object'
       }
     },
     'detectionState': {
@@ -376,15 +382,13 @@ module.exports = Object.freeze({
         'type': 'integer'
       }
     },
+    'playbackCommand': {
+      'itemTypes': ['Player']
+    },
     'playbackState': {
       'itemTypes': ['Player'],
       'state': {
-        'map': {
-          'default': {
-            'Player': {'PLAYING': 'PLAY', 'PAUSED': 'PAUSE'}
-          }
-        },
-        'type': 'string'
+        'type': 'object'
       }
     },
     'powerLevel': {

--- a/lambda/smarthome/alexa/propertyState.js
+++ b/lambda/smarthome/alexa/propertyState.js
@@ -120,6 +120,18 @@ const normalizeFunctions = {
   },
 
   /**
+   * Normalizes playback state value
+   * @param  {String} value
+   * @return {Object}
+   */
+  playbackState: function (value) {
+    const map = {'PLAY': 'PLAYING', 'PAUSE': 'PAUSED', 'REWIND': 'PLAYING', 'FASTFORWARD': 'PLAYING'};
+    return {
+      state: map[value]
+    };
+  },
+
+  /**
    * Normalizes power state value
    * @param  {*}      value
    * @return {String}

--- a/lambda/smarthome/alexa/v3/discovery.js
+++ b/lambda/smarthome/alexa/v3/discovery.js
@@ -291,7 +291,7 @@ function convertV2Item(item, config = {}) {
           capabilities = ['EqualizerController.modes'];
           break;
         case 'MediaPlayer':
-          capabilities = ['PlaybackController.playback'];
+          capabilities = ['PlaybackController.playback', 'PlaybackStateReporter.playbackState'];
           break;
         case 'SpeakerMute':
           capabilities = ['Speaker.muted'];

--- a/lambda/smarthome/alexa/v3/playbackController.js
+++ b/lambda/smarthome/alexa/v3/playbackController.js
@@ -38,7 +38,7 @@ class AlexaPlaybackController extends AlexaDirective {
    * Sends a playback command (PLAY, PASUE, REWIND, etc..) to a string or player item
    */
   setPlayback() {
-    const postItem = Object.assign({}, this.propertyMap.PlaybackController.playbackState.item, {
+    const postItem = Object.assign({}, this.propertyMap.PlaybackController.playback.item, {
       state: this.directive.header.name.toUpperCase()
     });
     this.postItemsAndReturn([postItem]);

--- a/lambda/smarthome/test/schemas/alexa_smart_home_message_schema.json
+++ b/lambda/smarthome/test/schemas/alexa_smart_home_message_schema.json
@@ -2801,6 +2801,114 @@
             }
           }
         },
+        "PlaybackStateReporter": {
+          "playbackState": {
+            "property": {
+              "type": "object",
+              "required": [
+                "namespace",
+                "name",
+                "value",
+                "timeOfSample",
+                "uncertaintyInMilliseconds"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "enum": [
+                    "Alexa.PlaybackStateReporter"
+                  ]
+                },
+                "name": {
+                  "enum": [
+                    "playbackState"
+                  ]
+                },
+                "value": {
+                  "type": "object",
+                  "required": [
+                    "state"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "state": {
+                      "enum": [
+                        "PLAYING",
+                        "PAUSED",
+                        "STOPPED"
+                      ]
+                    }
+                  }
+                },
+                "timeOfSample": {
+                  "$ref": "#/definitions/common.properties/timestamp"
+                },
+                "uncertaintyInMilliseconds": {
+                  "$ref": "#/definitions/common.properties/uncertaintyInMilliseconds"
+                }
+              }
+            }
+          },
+          "capabilities": {
+            "type": "object",
+            "required": [
+              "type",
+              "interface",
+              "version"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "enum": [
+                  "AlexaInterface"
+                ]
+              },
+              "interface": {
+                "enum": [
+                  "Alexa.PlaybackStateReporter"
+                ]
+              },
+              "version": {
+                "$ref": "#/definitions/common.properties/version"
+              },
+              "properties": {
+                "type": "object",
+                "required": [
+                  "supported",
+                  "proactivelyReported",
+                  "retrievable"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "supported": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "enum": [
+                            "playbackState"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "proactivelyReported": {
+                    "type": "boolean"
+                  },
+                  "retrievable": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
         "MotionSensor": {
           "detectionState": {
             "property": {
@@ -3245,6 +3353,9 @@
               "$ref": "#/definitions/common.properties/interfaces/EqualizerController/mode/property"
             },
             {
+              "$ref": "#/definitions/common.properties/interfaces/PlaybackStateReporter/playbackState/property"
+            },
+            {
               "$ref": "#/definitions/common.properties/interfaces/MotionSensor/detectionState/property"
             },
             {
@@ -3465,6 +3576,9 @@
                   },
                   {
                     "$ref": "#/definitions/common.properties/interfaces/PlaybackController/capabilities"
+                  },
+                  {
+                    "$ref": "#/definitions/common.properties/interfaces/PlaybackStateReporter/capabilities"
                   },
                   {
                     "$ref": "#/definitions/common.properties/interfaces/ContactSensor/capabilities"

--- a/lambda/smarthome/test/settings.js
+++ b/lambda/smarthome/test/settings.js
@@ -93,6 +93,9 @@ module.exports = {
       "PowerController": [
         "./v3/test_controllerPower.js"
       ],
+      "PlaybackStateReporter": [
+        "./v3/test_controllerPlaybackStateReporter.js"
+      ],
       "PowerLevelController": [
         "./v3/test_controllerPowerLevel.js"
       ],

--- a/lambda/smarthome/test/v3/test_controllerPlayback.js
+++ b/lambda/smarthome/test/v3/test_controllerPlayback.js
@@ -11,8 +11,8 @@ module.exports = [
         "cookie": {
           "propertyMap": JSON.stringify({
             "PlaybackController": {
-              "playbackState": {
-                "parameters": {}, "item": {"name": "speakerPlayer"}, "schema": {"name": "playbackState"}}}
+              "playback": {
+                "parameters": {}, "item": {"name": "speakerPlayer"}, "schema": {"name": "playbackCommand"}}}
           })
         }
       }

--- a/lambda/smarthome/test/v3/test_controllerPlaybackStateReporter.js
+++ b/lambda/smarthome/test/v3/test_controllerPlaybackStateReporter.js
@@ -1,0 +1,47 @@
+module.exports = [
+  {
+    description: "report state playback reporter",
+    directive: {
+      "header": {
+        "namespace": "Alexa",
+        "name": "ReportState"
+      },
+      "endpoint": {
+        "endpointId": "gSpeaker",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "PlaybackStateReporter": {
+              "playbackState": {
+                "parameters": {}, "item": {"name": "speakerPlayer", "type": "Player"},
+                "schema": {"name": "playbackState"}}}
+          })
+        }
+      }
+    },
+    mocked: {
+      openhab: {"name": "speakerPlayer", "state": "PLAY", "type": "Player"}
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [
+            {
+              "namespace": "Alexa.PlaybackStateReporter",
+              "name": "playbackState",
+              "value": {
+                "state": "PLAYING"
+              }
+            }
+          ]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "StateReport"
+          },
+        }
+      },
+      openhab: []
+    }
+  }
+];

--- a/lambda/smarthome/test/v3/test_discoverSpeaker.js
+++ b/lambda/smarthome/test/v3/test_discoverSpeaker.js
@@ -34,7 +34,7 @@ module.exports = {
           "tags": [],
           "metadata": {
             "alexa": {
-              "value": "PlaybackController.playbackState"
+              "value": "PlaybackController.playback,PlaybackStateReporter.playbackState"
             }
           },
           "groupNames": ["gSpeaker"]
@@ -135,6 +135,7 @@ module.exports = {
         "Alexa.Speaker.muted",
         "Alexa.Speaker.volume",
         "Alexa.PlaybackController",
+        "Alexa.PlaybackStateReporter.playbackState",
         "Alexa.EqualizerController.bands",
         "Alexa.EqualizerController.modes",
         "Alexa.EndpointHealth.connectivity"
@@ -150,7 +151,10 @@ module.exports = {
           "modes": {
             "supported": [{"name": "MOVIE"}, {"name": "TV"}]
           }
-        }
+        },
+        "Alexa.PlaybackController.supportedOperations": [
+          'Play', 'Pause', 'Next', 'Previous', 'Rewind', 'FastForward'
+        ]
       },
       "propertyMap": {
         "EqualizerController": {


### PR DESCRIPTION
For some unknown reason, the playback support is separated in two interfaces: one for commands and the other one for the current state. The former was already integrated under PlaybackController. This PR adds support for the latter.

https://developer.amazon.com/docs/device-apis/alexa-playbackstatereporter.html