### PR TITLE
Fix discovery friendly name determination bug

### DIFF
--- a/lambda/smarthome/alexa/v3/discovery.js
+++ b/lambda/smarthome/alexa/v3/discovery.js
@@ -44,7 +44,8 @@ class AlexaDiscovery extends AlexaDirective {
 
       items.forEach((item) => {
         // Set endpoint friendly name using item label or first synonyms metadata value
-        const friendlyName = item.label || item.metadata.synonyms && item.metadata.synonyms.value.split(',').shift();
+        const friendlyName = item.label ||
+          item.metadata && item.metadata.synonyms && item.metadata.synonyms.value.split(',').shift();
         // Skip item if friendly name empty or if already part of a group
         if (!friendlyName || groupItems.includes(item.name)) {
           return;

--- a/lambda/smarthome/test/v3/test_discoverLightColor.js
+++ b/lambda/smarthome/test/v3/test_discoverLightColor.js
@@ -50,6 +50,14 @@ module.exports = {
           }
         }
       }
+    },
+    {
+      "link": "https://localhost:8443/rest/items/light4",
+      "type": "Color",
+      "name": "light4",
+      "label": "", // Item skipped because no label or synonyms metadata value
+      "category": "lightbulb",
+      "tags": ["Lighting"]
     }
   ],
   expected: {


### PR DESCRIPTION
A bug was introduced with #214 where an item with no label and no metadata would cause the discovery process to fail with exception type error instead of just skipping the item as intended.

```
Switch TestSwitch ["Switchable"]
```

Fixes: #218