### PR TITLE
ThermostatController Setpoint Range Support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -138,7 +138,7 @@ While single mapping items works for many use cases, occasionally multiple openH
 
 For this example we will use various use cases, a thermostat, a stereo, a security system, a washer and a fan.
 
-In openHAB a thermostat is modeled as many different items, typically there are items for set points (target, heat, cool), modes, and the current temperature. To map these items to a single endpoint in Alexa, we will add them to a group which also uses "Alexa" metadata. When items are Alexa-enabled, but are also a member of a group Alexa-enabled, they will be added to the group endpoint and not exposed as their own endpoints.
+In openHAB a thermostat is modeled as many different items, typically there are items for setpoints (target, heat, cool), modes, and the current temperature. To map these items to a single endpoint in Alexa, we will add them to a group which also uses "Alexa" metadata. When items are Alexa-enabled, but are also a member of a group Alexa-enabled, they will be added to the group endpoint and not exposed as their own endpoints.
 
 ```
 Group  Thermostat    "Bedroom"                                {alexa="Endpoint.Thermostat"}
@@ -247,38 +247,41 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
       * Rollershutter
     * Default category: OTHER
   * `ThermostatController.targetSetpoint`
-    * Items that represent a target set point for a thermostat, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
+    * Items that represent a target setpoint for a thermostat. The scale is determined based on: (1) value set in parameter `scale="Fahrenheit"`; (2) unit of measurement unit if Number:Temperature item type; (3) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (4) defaults to Celsius. By default, the temperature range is limited to predefined setpoint values based on the scale parameter. If necessary, the temperature range can be customized using parameter `setpointRange="60:90"`.
     * Supported item type:
       * Number(:Temperature)
     * Supported metadata parameters:
       * scale=`<scale>`
-        * Celsius
-        * Fahrenheit
-        * Kelvin
+        * Celsius [10°C -> 32°C]
+        * Fahrenheit [50°F -> 90°F]
+      * setpointRange=`<minValue:maxValue>`
+        * defaults to defined scale range listed above if omitted
     * Default category: THERMOSTAT
   * `ThermostatController.upperSetpoint`
-    * Items that represent a upper or HEAT set point for a thermostat, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
+    * Items that represent a upper or HEAT setpoint for a thermostat. The scale is determined based on: (1) value set in parameter `scale="Fahrenheit"`; (2) unit of measurement unit if Number:Temperature item type; (3) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (4) defaults to Celsius. By default, the temperature range is limited to predefined setpoint values based on the scale parameter. If necessary, the temperature range can be customized using parameter `setpointRange="60:90"`.
     * Supported item type:
       * Number(:Temperature)
     * Supported metadata parameters:
       * scale=`<scale>`
-        * Celsius
-        * Fahrenheit
-        * Kelvin
+        * Celsius [10°C -> 32°C]
+        * Fahrenheit [50°F -> 90°F]
       * comfortRange=`<number>`
         * When dual setpoints (upper, lower) are used this is the amount over the requested temperature when requesting Alexa to set or adjust the current temperature.  Defaults to comfortRange=1 if using Fahrenheit and comfortRange=.5 if using Celsius. Ignored if a targetSetpoint is included in the thermostat group.
+      * setpointRange=`<minValue:maxValue>`
+        * defaults to defined scale range listed above if omitted
     * Default category: THERMOSTAT
   * `ThermostatController.lowerSetpoint`
-    * Items that represent a lower or COOL set point for a thermostat, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
+    * Items that represent a lower or COOL setpoint for a thermostat. The scale is determined based on: (1) value set in parameter `scale="Fahrenheit"`; (2) unit of measurement unit if Number:Temperature item type; (3) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (4) defaults to Celsius. By default, the temperature range is limited to predefined setpoint values based on the scale parameter. If necessary, the temperature range can be customized using parameter `setpointRange="60:90"`.
     * Supported item type:
       * Number(:Temperature)
     * Supported metadata parameters:
       * scale=`<scale>`
-        * Celsius
-        * Fahrenheit
-        * Kelvin
+        * Celsius [10°C -> 32°C]
+        * Fahrenheit [50°F -> 90°F]
       * comfortRange=`<number>`
         * When dual setpoints (upper,lower) are used this is the amount under the requested temperature when requesting Alexa to set or adjust the current temperature.  Defaults to comfortRange=1 if using Fahrenheit and comfortRange=.5 if using Celsius.  Ignored if a targetSetpoint is included in the thermostat group.
+      * setpointRange=`<minValue:maxValue>`
+        * defaults to defined scale range listed above if omitted
     * Default category: THERMOSTAT
   * `ThermostatController.thermostatMode`
     * Items that represent the mode for a thermostat, default string values are "OFF=off,HEAT=heat,COOL=cool,ECO=eco,AUTO=auto", but these can be mapped to other values in the metadata. The mapping can be, in order of precedence, user-defined (AUTO=3,...) or preset-based related to the thermostat binding used (binding=`<value>`). For the binding parameter, it will be automatically determined if the associated item is using a 2.x addon (via channel metadata). If neither of these settings are provided, for thermostats that only support a subset of the standard modes, a comma delimited list of the Alexa supported modes should be set using the supportedModes parameter, otherwise, the supported list will be compiled based of the default mapping.
@@ -304,14 +307,13 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * defaults to, depending on the parameters provided, either user-based, preset-based or default item type-based mapping.
     * Default category: THERMOSTAT
   * `TemperatureSensor.temperature`
-    * Items that represent the current temperature, value may be in Celsius or Fahrenheit depending on how the item is configured (e.g., scale=Fahrenheit). If omitted, the scale will be determined based on: (1) unit of measurement unit if Number:Temperature item type; (2) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (3) defaults to Celsius.
+    * Items that represent the current temperature. The scale is determined based on: (1) value set in parameter `scale="Fahrenheit"`; (2) unit of measurement unit if Number:Temperature item type; (3) your openHAB server regional measurement system or region settings (US=Fahrenheit; SI=Celsius); (4) defaults to Celsius.
     * Supported item type:
       * Number(:Temperature)
     * Supported metadata parameters:
       * scale=`<scale>`
         * Celsius
         * Fahrenheit
-        * Kelvin
     * Default category: TEMPERATURE_SENSOR
   * `LockController.lockState`
     * Items that represent the state of a lock (ON lock, OFF unlock). When associated to an [item sensor](#item-sensor), the state of that item will be returned instead of the original actionable item. Additionally, when linking to such item, multiple properties to one state can be mapped with column delimiter (e.g. for a Z-Wave lock: [LOCKED="1:3",UNLOCKED="2:4",JAMMED=11]).

--- a/lambda/smarthome/alexa/capabilities.js
+++ b/lambda/smarthome/alexa/capabilities.js
@@ -251,6 +251,17 @@ function isSupportedAssetId(assetId) {
 }
 
 /**
+ * Returns alexa property schema values for a given schema name and optional object path
+ * @param  {Object} schema
+ * @param  {String} path    (optional)
+ * @return {*}
+ */
+function getPropertySchema(schema, path = '') {
+  return path.split('.').slice(1).reduce(
+    (values, key) => typeof values === 'object' ? values[key] : undefined, PROPERTY_SCHEMAS[schema]);
+}
+
+/**
  * Returns alexa property settings for a given capability
  *
  *  {
@@ -276,7 +287,7 @@ function getPropertySettings(interfaceName, propertyName) {
   const properties = CAPABILITIES[interfaceName] && CAPABILITIES[interfaceName]['properties'] || [];
   const property = properties.find(property => property.name === propertyName) || {};
 
-  return Object.assign({}, property, PROPERTY_SCHEMAS[property.schema]);
+  return Object.assign({}, property, getPropertySchema(property.schema));
 }
 
 /**
@@ -290,8 +301,7 @@ function getPropertySettings(interfaceName, propertyName) {
  */
 function getPropertyStateMap(property) {
   const parameters = property.parameters;
-  const schema = PROPERTY_SCHEMAS[property.schema.name] || {};
-  const stateMap = schema.state && schema.state.map || {};
+  const stateMap = getPropertySchema(property.schema.name, '.state.map') || {};
   const type = property.item.type;
 
   // Define custom map if defined in schema state map
@@ -341,6 +351,7 @@ function isSupportedDisplayCategory(category) {
 module.exports = {
   getCapabilityCategory: getCapabilityCategory,
   getCapabilityInterface: getCapabilityInterface,
+  getPropertySchema: getPropertySchema,
   getPropertySettings: getPropertySettings,
   getPropertyStateMap: getPropertyStateMap,
   isInColorMode: isInColorMode,

--- a/lambda/smarthome/alexa/config.js
+++ b/lambda/smarthome/alexa/config.js
@@ -315,10 +315,7 @@ module.exports = Object.freeze({
             'yeelight': (type) =>
               ['white', 'ceiling', 'dolphin'].includes(type) ? [2700, 6500] : [1700, 6500]
           },
-          'default': {
-            'Dimmer': [1000, 10000],
-            'Number': [1000, 10000]
-          }
+          'default': [1000, 10000]
         },
         'type': 'integer'
       }
@@ -463,6 +460,12 @@ module.exports = Object.freeze({
     'temperature': {
       'itemTypes': ['Number', 'Number:Temperature'],
       'state': {
+        'range': {
+          'default': {
+            'comfort': {'CELSIUS': .5, 'FAHRENHEIT': 1},
+            'setpoint': {'CELSIUS': [10, 32], 'FAHRENHEIT': [50, 90]}
+          }
+        },
         'type': 'object'
       }
     },

--- a/lambda/smarthome/alexa/propertyState.js
+++ b/lambda/smarthome/alexa/propertyState.js
@@ -14,8 +14,7 @@
 /**
  * Amazon Smart Home Skill Property State for API V3
  */
-const { getPropertyStateMap } = require('./capabilities.js');
-const { PROPERTY_SCHEMAS } = require('./config.js');
+const { getPropertySchema, getPropertyStateMap } = require('./capabilities.js');
 
 /**
  * Defines normalize functions
@@ -80,7 +79,7 @@ const normalizeFunctions = {
    */
   colorTemperatureInKelvin: function (value, property) {
     const type = property.item.type;
-    const defaultRange = PROPERTY_SCHEMAS.colorTemperatureInKelvin.state.range.default[type];
+    const defaultRange = getPropertySchema('colorTemperatureInKelvin', '.state.range.default');
     const temperatureRange = property.parameters.range || defaultRange;
     const minValue = Math.max(temperatureRange[0], defaultRange[0]);
     const maxValue = Math.min(temperatureRange[1], defaultRange[1]);
@@ -112,7 +111,7 @@ const normalizeFunctions = {
   inputs: function (value) {
     const input = value.replace(/(\S)(\d+)$/, '$1 $2').toUpperCase();
 
-    if (PROPERTY_SCHEMAS.inputs.state.supported.includes(input)) {
+    if (getPropertySchema('inputs', '.state.supported').includes(input)) {
       return input;
     }
   },
@@ -164,7 +163,7 @@ const normalizeFunctions = {
    */
   temperature: function (temperature, property, options = {}) {
     const isDelta = options.isDelta === true;
-    const scale = property.parameters.scale || 'CELSIUS';
+    const scale = property.parameters.scale;
 
     // Convert OH to Alexa
     if (typeof temperature !== 'object') {

--- a/lambda/smarthome/test/v3/test_controllerAlexa.js
+++ b/lambda/smarthome/test/v3/test_controllerAlexa.js
@@ -84,7 +84,7 @@ module.exports = [
           "propertyMap": JSON.stringify({
             "TemperatureSensor": {
               "temperature": {
-                "parameters": {"scale": "Fahrenheit"},
+                "parameters": {"scale": "FAHRENHEIT"},
                 "item": {"name": "temperature1", "type": "Number:Temperature"},
                 "schema": {"name": "temperature"}
               }
@@ -133,11 +133,11 @@ module.exports = [
         "cookie": {
           "propertyMap": JSON.stringify({
             "ThermostatController": {
-              "targetSetpoint": {"parameters": {"scale": "Fahrenheit"},
+              "targetSetpoint": {"parameters": {"scale": "FAHRENHEIT"},
                 "item": {"name": "targetTemperature", "type": "Number"}, "schema": {"name": "temperature"}},
-              "upperSetpoint": {"parameters": {"scale": "Fahrenheit"},
+              "upperSetpoint": {"parameters": {"scale": "FAHRENHEIT"},
                 "item": {"name": "highTargetTemperature", "type": "Number"}, "schema": {"name": "temperature"}},
-              "lowerSetpoint": {"parameters": {"scale": "Fahrenheit"},
+              "lowerSetpoint": {"parameters": {"scale": "FAHRENHEIT"},
                 "item": {"name": "lowTargetTemperature", "type": "Number"}, "schema": {"name": "temperature"}}
             }
           })

--- a/lambda/smarthome/test/v3/test_controllerThermostatTemperature.js
+++ b/lambda/smarthome/test/v3/test_controllerThermostatTemperature.js
@@ -297,6 +297,58 @@ module.exports = [
     }
   },
   {
+    description: "set target temperature out of range error",
+    directive: {
+      "header": {
+        "namespace": "Alexa.ThermostatController",
+        "name": "SetTargetTemperature"
+      },
+      "endpoint": {
+        "endpointId": "gThermostat",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "ThermostatController": {
+              "targetSetpoint": {"parameters": {"scale": "FAHRENHEIT"},
+                "item": {"name": "targetTemperature"}, "schema": {"name": "temperature"}}
+            }
+          })
+        }
+      },
+      "payload": {
+        "targetSetpoint": {
+          "value": 40,
+          "scale": "FAHRENHEIT"
+        },
+      }
+    },
+    mocked: {},
+    expected: {
+      alexa: {
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "ErrorResponse"
+          },
+          "payload": {
+            "type": "TEMPERATURE_VALUE_OUT_OF_RANGE",
+            "message": "The target setpoint temperature cannot be set to 40°F.",
+            "validRange": {
+              "minimumValue": {
+                "value": 50,
+                "scale": "FAHRENHEIT"
+              },
+              "maximumValue": {
+                "value": 90,
+                "scale": "FAHRENHEIT"
+              }
+            }
+          }
+        }
+      },
+      openhab: []
+    }
+  },
+  {
     description: "adjust target temperature",
     directive: {
       "header": {
@@ -481,6 +533,64 @@ module.exports = [
       },
       openhab: [
         {"name": "targetTemperature", "value": 75.6}
+      ]
+    }
+  },
+  {
+    description: "adjust target temperature with capping",
+    directive: {
+      "header": {
+        "namespace": "Alexa.ThermostatController",
+        "name": "AdjustTargetTemperature"
+      },
+      "endpoint": {
+        "endpointId": "gThermostat",
+        "cookie": {
+          "propertyMap": JSON.stringify({
+            "ThermostatController": {
+              "targetSetpoint": {"parameters": {"scale": "FAHRENHEIT", "setpointRange": [60, 90]},
+                "item": {"name": "targetTemperature"}, "schema": {"name": "temperature"}}
+            }
+          })
+        }
+      },
+      "payload": {
+        "targetSetpointDelta": {
+          "value": -2.0,
+          "scale": "FAHRENHEIT"
+        }
+      }
+    },
+    mocked: {
+      openhab: [
+        {"name": "targetTemperature", "state": "60", "type": "Number"},
+        {"name": "targetTemperature", "state": "60", "type": "Number"}
+      ],
+      staged: true
+    },
+    expected: {
+      alexa: {
+        "context": {
+          "properties": [
+            {
+              "namespace": "Alexa.ThermostatController",
+              "name": "targetSetpoint",
+              "value": {
+                "value": 60,
+                "scale": "FAHRENHEIT"
+              }
+            }
+          ]
+        },
+        "event": {
+          "header": {
+            "namespace": "Alexa",
+            "name": "Response"
+          }
+        }
+      },
+      openhab: [
+        {"name": "targetTemperature", "value": 60}
       ]
     }
   }

--- a/lambda/smarthome/test/v3/test_discoverThermostat.js
+++ b/lambda/smarthome/test/v3/test_discoverThermostat.js
@@ -194,7 +194,8 @@ module.exports = {
             "alexa": {
               "value": "ThermostatController.targetSetpoint",
               "config": {
-                "scale": "Fahrenheit"
+                "scale": "Fahrenheit",
+                "setpointRange": "60:90"
               }
             }
           },
@@ -259,7 +260,7 @@ module.exports = {
     },
     {
       "link": "https://myopenhab.org/rest/items/temperature2",
-      "state": "295 K",
+      "state": "20 °C",
       "type": "Number:Temperature",
       "name": "temperature2",
       "label": "Temperature 2",
@@ -312,24 +313,24 @@ module.exports = {
       "propertyMap": {
         "TemperatureSensor": {
           "temperature": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "currentTemperature1", "type": "Number"},
             "schema": {"name": "temperature"}
           }
         },
         "ThermostatController": {
           "targetSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "targetTemperature1", "type": "Number"},
             "schema": {"name": "temperature"}
           },
           "upperSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "highTargetTemperature1", "type": "Number"},
             "schema": {"name": "temperature"}
           },
           "lowerSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "lowTargetTemperature1", "type": "Number"},
             "schema": {"name": "temperature"}
           },
@@ -362,24 +363,24 @@ module.exports = {
       "propertyMap": {
         "TemperatureSensor": {
           "temperature": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "currentTemperature2", "type": "Number"},
             "schema": {"name": "temperature"}
           }
         },
         "ThermostatController": {
           "targetSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "targetTemperature2", "type": "Number"},
             "schema": {"name": "temperature"}
           },
           "upperSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "highTargetTemperature2", "type": "Number"},
             "schema": {"name": "temperature"}
           },
           "lowerSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "lowTargetTemperature2", "type": "Number"},
             "schema": {"name": "temperature"}
           },
@@ -417,7 +418,7 @@ module.exports = {
       "propertyMap": {
         "ThermostatController": {
           "targetSetpoint": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT", "setpointRange": [60, 90]},
             "item": {"name": "targetTemperature4", "type": "Number"},
             "schema": {"name": "temperature"}
           }
@@ -450,7 +451,7 @@ module.exports = {
       "propertyMap": {
         "TemperatureSensor": {
           "temperature": {
-            "parameters": {"scale": "Fahrenheit"},
+            "parameters": {"scale": "FAHRENHEIT"},
             "item": {"name": "temperature1", "type": "Number"},
             "schema": {"name": "temperature"}
           }
@@ -468,7 +469,7 @@ module.exports = {
       "propertyMap": {
         "TemperatureSensor": {
           "temperature": {
-            "parameters": {"scale": "KELVIN"},
+            "parameters": {"scale": "CELSIUS"},
             "item": {"name": "temperature2", "type": "Number:Temperature"},
             "schema": {"name": "temperature"}
           }


### PR DESCRIPTION
* added support for ThermostatController setpoint range
* forced temperature schema scale parameter to always be stored as uppercase
* added capabilities function to retrieve nested property schema values
* removed item type dependency for color temperature default range state
* refactored ThermostatController comfort range code to use schema properties
* removed unnecessary kelvin temperature scale schema support