### PR TITLE
Ignore specific mode range non-controllable property parameters

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -521,6 +521,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * each name formatted as `<@assetIdOrName>`
         * defaults to item label name
       * nonControllable=`<boolean>`
+        * when set to true, supportedModes and ordered parameters are ignored
         * defaults to false
       * supportedModes=`<modes>`
         * each mode formatted as `<modeValue>=<@assetIdOrName1>:<@assetIdOrName2>:...`
@@ -545,6 +546,7 @@ Number:Temperature Temperature2 "Temperature"           {alexa="TemperatureSenso
         * each name formatted as `<@assetIdOrName>`
         * defaults to item label name
       * nonControllable=`<boolean>`
+        * when set to true, supportedRange and presets parameters are ignored
         * defaults to false
       * supportedRange=`<minValue:maxValue:precision>`
         * defaults to `"0:100:1"` for Dimmer/Rollershutter, `"0:10:1"` for Number* item types

--- a/lambda/smarthome/alexa/v3/capabilities.js
+++ b/lambda/smarthome/alexa/v3/capabilities.js
@@ -151,7 +151,7 @@ function getCapabilityInterface(interfaceName, properties, settings = {}) {
         capability.inputs = parameters.supportedInputs.map(input => Object.assign({name: input}));
         break;
       case 'mode':
-        Object.assign(configuration, {
+        Object.assign(configuration, parameters.supportedModes && {
           'ordered': parameters.ordered === true,
           'supportedModes': parameters.supportedModes.map(mode => ({
             'value': mode.split('=').shift(),
@@ -164,7 +164,7 @@ function getCapabilityInterface(interfaceName, properties, settings = {}) {
         capability.supportedOperations = ['Play', 'Pause', 'Next', 'Previous', 'Rewind', 'FastForward'];
         break;
       case 'rangeValue':
-        Object.assign(configuration, Object.assign({
+        Object.assign(configuration, parameters.supportedRange && {
           'supportedRange': parameters.supportedRange
         }, parameters.unitOfMeasure && {
           'unitOfMeasure': 'Alexa.Unit.' + parameters.unitOfMeasure
@@ -174,7 +174,7 @@ function getCapabilityInterface(interfaceName, properties, settings = {}) {
             'presetResources': getResourcesObject({
               labels: preset.split(/[=:]/).slice(1), locale: parameters.locale || locale})
           }))
-        }));
+        });
         break;
       case 'scene':
         capability.supportsDeactivation = parameters.supportsDeactivation === false ? false : true;

--- a/lambda/smarthome/test/schemas/alexa_smart_home_message_schema.json
+++ b/lambda/smarthome/test/schemas/alexa_smart_home_message_schema.json
@@ -2182,8 +2182,7 @@
               "interface",
               "version",
               "instance",
-              "capabilityResources",
-              "configuration"
+              "capabilityResources"
             ],
             "additionalProperties": false,
             "properties": {
@@ -2249,10 +2248,6 @@
               },
               "configuration": {
                 "type": "object",
-                "required": [
-                  "ordered",
-                  "supportedModes"
-                ],
                 "additionalProperties": false,
                 "properties": {
                   "ordered": {
@@ -2344,8 +2339,7 @@
               "interface",
               "version",
               "instance",
-              "capabilityResources",
-              "configuration"
+              "capabilityResources"
             ],
             "additionalProperties": false,
             "properties": {
@@ -2411,9 +2405,6 @@
               },
               "configuration": {
                 "type": "object",
-                "required": [
-                  "supportedRange"
-                ],
                 "additionalProperties": false,
                 "properties": {
                   "supportedRange": {

--- a/lambda/smarthome/test/v3/test_discoverWasher.js
+++ b/lambda/smarthome/test/v3/test_discoverWasher.js
@@ -73,7 +73,6 @@ module.exports = {
         "alexa": {
           "value": "ModeController.mode",
           "config": {
-            "supportedModes": "Wash,Rinse,Spin",
             "friendlyNames": "Wash Cycle Status",
             "nonControllable": true
           }
@@ -165,20 +164,6 @@ module.exports = {
               "friendlyNames": ["text:High:en-US"]
             }
           }
-        },
-        "Alexa.ModeController.WashCycleStatus": {
-          "ordered": false,
-          "supportedModes": {
-            "Wash": {
-              "friendlyNames": ["text:Wash:en-US"]
-            },
-            "Rinse": {
-              'friendlyNames': ["text:Rinse:en-US"]
-            },
-            "Spin": {
-              'friendlyNames': ["text:Spin:en-US"]
-            }
-          }
         }
       },
       "propertyMap": {
@@ -212,7 +197,6 @@ module.exports = {
         "ModeController:WashCycleStatus": {
           "mode": {
             "parameters": {
-              "supportedModes": ["Wash=Wash", "Rinse=Rinse", "Spin=Spin"],
               "friendlyNames": ["Wash Cycle Status"], "nonControllable": true},
             "item": {"name": "WashCycleStatus", "type": "String"},
             "schema": {"name": "mode"}


### PR DESCRIPTION
Some of the mode/range property parameters are only used to configure how a user interacts with these components via voice commands. These aren't needed when these properties are non-controllable and therefore cannot receive any commands.