### PR TITLE
Add current humidity and outlet metadata labels

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -730,7 +730,6 @@ Weight.Ounces |
 #### Supported Metadata Labels
 Item metadata labels translate to a set of capabilities and can be used as a convenience to using the longer meta data format configuration.  These add additional functions and provide the ability to add customization through additional properties which take precedence over the default ones. Here are some examples:
 ```
-Switch OutletPlug "Outlet Plug" {alexa="Switchable" [category="SMARTPLUG"]}
 Switch TelevisionPower "Television Power" {alexa="Switchable" [category="TV"]}
 
 Color LightColor "Light Color" {alexa="Lighting"}
@@ -754,12 +753,23 @@ Color LightColor "Light Color" {alexa="Lighting"}
 Dimmer LightDimmer "Light Dimmer" {alexa="PowerController.powerState,BrightnessController.brightness" [category="LIGHT"]}
 Color LightColor "Light Color" {alexa="PowerController.powerState,BrightnessController.brightness,ColorController.color" [category="LIGHT"]}
 ```
-
 * Lock
 ```
 Switch DoorLock "Door Lock" {alexa="Lock"}
 
 Switch DoorLock "Door Lock" {alexa="LockController.lockState"}
+```
+* Outlet
+```
+Switch OutletPlug "Outlet Plug" {alexa="Outlet"}
+
+Switch OutletPlug "Outlet Plug" {alexa="PowerController.powerState" [category="SMARTPLUG"]}
+```
+* CurrentHumidity
+```
+Number CurrentHumidity "Current Humidity" {alexa="CurrentHumidity"}
+
+Number CurrentHumidity "Current Humidity" {alexa="RangeController.rangeValue" [friendlyNames="Humidity", nonControllable=true, unitOfMeasure="Percent"]}
 ```
 * CurrentTemperature
 ```

--- a/lambda/smarthome/alexa/v3/directives/discovery.js
+++ b/lambda/smarthome/alexa/v3/directives/discovery.js
@@ -270,6 +270,14 @@ function convertV2Item(item, config = {}) {
         case 'Lock':
           capabilities = ['LockController.lockState'];
           break;
+        case 'Outlet':
+          capabilities = ['PowerController.powerState'];
+          parameters = {category: 'SMARTPLUG'};
+          break;
+        case 'CurrentHumidity':
+          capabilities = ['RangeController.rangeValue'];
+          parameters = {friendlyNames: 'Humidity', nonControllable: true, unitOfMeasure: 'Percent'};
+          break;
         case 'CurrentTemperature':
           capabilities = ['TemperatureSensor.temperature'];
           parameters = {scale: config.scale || getV2TemperatureScale()};

--- a/lambda/smarthome/test/settings.js
+++ b/lambda/smarthome/test/settings.js
@@ -65,6 +65,9 @@ module.exports = {
       "Lock": [
         "./v3/test_discoverLock.js"
       ],
+      "Outlet": [
+        "./v3/test_discoverOutlet.js"
+      ],
       "Scene": [
         "./v3/test_discoverScene.js"
       ],

--- a/lambda/smarthome/test/v3/test_discoverOutlet.js
+++ b/lambda/smarthome/test/v3/test_discoverOutlet.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+module.exports = {
+  description: "outlet plug",
+  mocked: [
+    {
+      "type": "Switch",
+      "name": "outletPlug",
+      "label": "Outlet Plug",
+      "tags": ["Outlet"]
+    }
+  ],
+  expected: {
+    "outletPlug": {
+      "capabilities": [
+        "Alexa",
+        "Alexa.PowerController.powerState",
+        "Alexa.EndpointHealth.connectivity"
+      ],
+      "displayCategories": ["SMARTPLUG"],
+      "friendlyName": "Outlet Plug"
+    }
+  }
+};

--- a/lambda/smarthome/test/v3/test_discoverThermostat.js
+++ b/lambda/smarthome/test/v3/test_discoverThermostat.js
@@ -16,6 +16,12 @@ module.exports = {
   mocked: [
     {
       "type": "Number",
+      "name": "currentHumidity1",
+      "tags": ["CurrentHumidity"],
+      "groupNames": ["gThermostat1"]
+    },
+    {
+      "type": "Number",
       "name": "currentTemperature1",
       "tags": ["CurrentTemperature"],
       "groupNames": ["gThermostat1"]
@@ -267,6 +273,7 @@ module.exports = {
     "gThermostat1": {
       "capabilities": [
         "Alexa",
+        "Alexa.RangeController.currentHumidity1.rangeValue",
         "Alexa.TemperatureSensor.temperature",
         "Alexa.ThermostatController.targetSetpoint",
         "Alexa.ThermostatController.upperSetpoint",
@@ -276,12 +283,27 @@ module.exports = {
       ],
       "displayCategories": ["THERMOSTAT"],
       "friendlyName": "Thermostat 1",
+      "resources": {
+        "Alexa.RangeController.currentHumidity1": {
+          "friendlyNames": ["text:Humidity:en-US"]
+        }
+      },
       "configuration": {
+        "Alexa.RangeController.currentHumidity1": {
+          "unitOfMeasure": "Alexa.Unit.Percent"
+        },
         "Alexa.ThermostatController": {
           "supportsScheduling": false
         }
       },
       "propertyMap": {
+        "RangeController:currentHumidity1": {
+          "rangeValue": {
+            "parameters": {"friendlyNames": ["Humidity"], "nonControllable": true, "unitOfMeasure": "Percent"},
+            "item": {"name": "currentHumidity1", "type": "Number"},
+            "schema": {"name": "rangeValue"}
+          }
+        },
         "TemperatureSensor": {
           "temperature": {
             "parameters": {"scale": "FAHRENHEIT"},


### PR DESCRIPTION
In line with the [Google Assistant item configuration](https://www.openhab.org/docs/ecosystem/google-assistant/#item-configuration) current integration, the `CurrentHumidity` and `Outlet` metadata labels have been added, with the former currently only available in the US since it's based of a non-controllable range controller interface, but should be shortly  available in other languages based on Amazon's recent [announcement](https://developer.amazon.com/blogs/alexa/post/49eff766-5d95-4faf-9205-2ab52ae8a437/announcing-updated-smart-home-building-block-apis-non-controllable-device-states-semantic-extensions-and-expanded-international-support).