### PR TITLE
Add reference to config example with channel metadata

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,10 @@ In the Alexa skill a light switch endpoint implements the "PowerController" inte
 Switch LightSwitch "Light Switch" {alexa="PowerController.powerState"}
 ```
 Setting this on a single item will create an Alexa endpoint with the spoken addressable name "Light Switch" and map the powerState property to our item. You can ask Alexa to turn "Light Switch" on or off.
+Note: If you have already defined a channel linking then add the Alexa mapping after the channel separated with a comma. An example ZWave switch is given below.
+```
+Switch LightSwitch "Light Switch" {channel="zwave:device:22c99d1e:node3:switch_binary", alexa="PowerController.powerState"}
+```
 
 This can also be written using [metadata labels](#supported-metadata-labels), which is a shorthand version of the full Alexa namespace:
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -96,10 +96,8 @@ In the Alexa skill a light switch endpoint implements the "PowerController" inte
 Switch LightSwitch "Light Switch" {alexa="PowerController.powerState"}
 ```
 Setting this on a single item will create an Alexa endpoint with the spoken addressable name "Light Switch" and map the powerState property to our item. You can ask Alexa to turn "Light Switch" on or off.
-Note: If you have already defined a channel linking then add the Alexa mapping after the channel separated with a comma. An example ZWave switch is given below.
-```
-Switch LightSwitch "Light Switch" {channel="zwave:device:22c99d1e:node3:switch_binary", alexa="PowerController.powerState"}
-```
+
+An example of how this works with other metadata is given in [Items Metadata](https://www.openhab.org/docs/concepts/items.html#item-metadata)
 
 This can also be written using [metadata labels](#supported-metadata-labels), which is a shorthand version of the full Alexa namespace:
 ```


### PR DESCRIPTION
This took me a while to find on the Forum and its not documented in the openHAB Amazon Alexa Smart Home Skill.
https://community.openhab.org/t/tagging-devices-for-alexa-support/98155/3