### PR TITLE
Update turn on/off custom action semantics

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -422,22 +422,20 @@ Number Battery   "Battery"    (SmartWatch) {alexa="BatteryLevel"}
 
 Semantic extensions are used to further customize how to interact with a device. This functionality is only supported by the [generic attributes](#generic-attributes). The Alexa API currently provides `Close`, `Open`, `Lower` and `Raise` interactions, removing the need for the Alexa routine workaround to control certain devices such as blinds or doors. Additionally, the skills now includes `Pause`, `Resume`, `Stop`, `TurnOff` and `TurnOn` custom interactions. Each semantic is composed of action and state mappings. The actions are used for interacting with the device and the states for displaying its current semantic state in the Alexa app (Not available as of yet). The supported action and state names are listed in the [semantic catalog](#semantic-catalog).
 
-The skill-based `Pause`, `Resume` and `Stop` semantics can only be set as action mappings. On the other side, the `TurnOn` and `TurnOff` semantics can be paired with `On` and `Off` state mappings to report a state if necessary (e.g. *Alexa, is `<device>` `<capability>` on?*). These state mappings can also be set without action mappings for status purpose only, and can be defined, depending on the item type, as a specific value `On=ON`, a pipe-delimited list of values `On=LOW|MEDIUM|HIGH`, or a range `On=1:5`.
-
-It is important to note that besides `TurnOff` and `TurnOn` action and `Off`/`On` state semantics, only one semantic type is allowed per endpoint. Additionally, adjust action mappings (e.g `Raise=(+10)`) are only supported by Alexa API action semantics.
+It is important to note that only one semantic type is allowed per endpoint. Additionally, adjust action mappings (e.g `Raise=(+10)`) are only supported by Alexa API action semantics.
 
 Here is how some the [device attributes](#device-attributes) using semantic extensions are translating to:
 
 A window blind [position state](#position-state). For example, when requesting *Alexa, open the blind*, the item will receive command `UP`. Likewise, when asking *Alexa, lower the blind*, it will receive command `DOWN`. And when requesting *Alexa, stop the blind*, it will receive command `STOP`. For position request, since Rollershutter range value are inverted by default, when requesting *Alexa, set the blind to 40%*, the item state will be set to `60`.
 
 ```xtend
-Rollershutter Blind "Blind" {alexa="Blind.RangeValue" [capabilityNames="@Setting.Position", supportedCommands="UP=@Value.Up:@Value.Open,DOWN=@Value.Down:@Value.Close,STOP=@Value.Stop", supportedRange="0:100:1", unitOfMeasure="Percent", actionMappings="Close=DOWN,Open=UP,Lower=DOWN,Raise=UP", stateMappings="Closed=100,Open=0:99"]}
+Rollershutter Blind "Blind" {alexa="Blind.RangeValue" [capabilityNames="@Setting.Position", supportedCommands="UP=@Value.Up:@Value.Open,DOWN=@Value.Down:@Value.Close,STOP=@Value.Stop", supportedRange="0:100:1", unitOfMeasure="Percent", actionMappings="Close=DOWN,Open=UP,Lower=DOWN,Raise=UP,Stop=STOP", stateMappings="Closed=100,Open=0:99"]}
 ```
 
 A window curtain [position state](#position-state). For example, when requesting *Alexa, open the curtain*, the item state will be set to `100`. Likewise, when asking *Alexa, close the blind*, it be set to `0`.
 
 ```xtend
-Dimmer Curtain "Curtain" {alexa="Curtain.RangeValue" [capabilityNames="@Setting.Position", supportedRange="0:100:1", presets="0=@Value.Close,100=@Value.Open", unitOfMeasure="Percent", actionMappings="Close=0,Open=100", stateMappings="Closed=0,Open=1:100"]}
+Dimmer Curtain "Curtain" {alexa="Curtain.RangeValue" [capabilityNames="@Setting.Position", supportedRange="0:100:1", unitOfMeasure="Percent", actionMappings="Close=0,Open=100", stateMappings="Closed=0,Open=1:100"]}
 ```
 
 A door [open state](#open-state). For example, when requesting *Alexa, open the door*, the item state will be set to `ON`.
@@ -449,7 +447,7 @@ Switch Door "Door" {alexa="Door.Mode" [capabilityNames="@Setting.Opening", suppo
 A vacuum cleaner [mode](#vacuum-mode). For example, when requesting *Alexa, turn on the vacuum cleaner*, the item state will be set to `CLEAN`. Likewise, when asking *Alexa, pause the vacuum cleaner*, it be set to `PAUSE`. And when requesting *Alexa, resume the vacuum cleaner*, it will be set to `CLEAN` again.
 
 ```xtend
-String VacuumCleaner "Vacuum Cleaner" {alexa="VacuumCleaner.Mode" [capabilityNames="@Setting.Mode", supportedModes="CLEAN=@Setting.Clean,DOCK=@Setting.Dock,SPOT=@Setting.Spot,PAUSE=@Setting.Pause,STOP=@Setting.Stop", actionMappings="Resume=DOCK,Pause=PAUSE,Stop=STOP,TurnOn=CLEAN,TurnOff=DOCK", stateMappings="Off=DOCK|PAUSE|STOP,On=CLEAN|SPOT"]}
+String VacuumCleaner "Vacuum Cleaner" {alexa="VacuumCleaner.Mode" [capabilityNames="@Setting.Mode", supportedModes="CLEAN=@Setting.Clean,DOCK=@Setting.Dock,SPOT=@Setting.Spot,PAUSE=@Setting.Pause,STOP=@Setting.Stop", actionMappings="Resume=CLEAN,Pause=PAUSE,Stop=STOP,TurnOn=CLEAN,TurnOff=DOCK"]}
 ```
 
 # Item Configuration
@@ -1641,14 +1639,13 @@ Items that represent components of a device that have more than one setting. Mul
       * set => `<action>=<mode>`
       * adjust => `<action>=(<deltaValue>)` (Supported only if `ordered=true`)
     * [supported action semantics](#semantic-catalog)
-    * only one specific action semantic allowed per endpoint, except for `TurnOn` and `TurnOff`
-    * no support for `TurnOn` and `TurnOff` semantics on Switch, use [`ToggleState`](#togglestate) instead
+    * only one given action semantic allowed per endpoint
+    * no support for `TurnOn` and `TurnOff` semantics on Switch, use [`PowerState`](#powerstate) instead
     * defaults to no actions
   * stateMappings=`<mappings>`
     * each [semantic](#semantic-extensions) mapping formatted as `<state>=<mode>` (e.g. `stateMappings="Closed=CLOSED,Open=OPEN"`)
     * [supported state semantics](#semantic-catalog)
-    * only one specific state semantic allowed per endpoint, except for `On` and `Off`
-    * no support for `On` and `Off` semantics on Switch, use [`ToggleState`](#togglestate) instead
+    * only one given state semantic allowed per endpoint
     * defaults to no states
 * Utterance examples:
   * *Alexa, set the `<device name>` `<capability name>` to `<mode name>`.*
@@ -1662,8 +1659,8 @@ Items that represent components of a device that have more than one setting. Mul
   * *Alexa, resume the `<device name>`.* (if `Resume` action defined)
   * *Alexa, pause the `<device name>`.* (if `Pause` action defined)
   * *Alexa, stop the `<device name>`.* (if `Stop` action defined)
-  * *Alexa, turn on the `<device name>` `<capability name>`.* (if `TurnOn` action defined)
-  * *Alexa, turn off the `<device name>` `<capability name>`.* (if `TurnOff` action defined)
+  * *Alexa, turn on the `<device name>`.* (if `TurnOn` action defined)
+  * *Alexa, turn off the `<device name>`.* (if `TurnOff` action defined)
 
 <a name="rangecontroller-rangevalue"></a>
 <a name="rangecomponent"></a>
@@ -1726,20 +1723,17 @@ Items that represent components of a device that are characterized by numbers wi
       * adjust => `<action>=(<deltaValue>)`
     * supported commands can be mapped as well (e.g. `actionMappings="Close=DOWN,Open=UP,Lower=DOWN,Raise=UP,Stop=STOP"`)
     * [supported action semantics](#semantic-catalog)
-    * only one specific action semantic allowed per endpoint, except for `TurnOn` and `TurnOff`
+    * only one given action semantic allowed per endpoint
     * no support for:
       * any [custom semantics](#custom-semantic-catalog) on Number with defined dimension
-      * `TurnOn` and `TurnOff` semantics on Rollershutter
+      * `TurnOn` and `TurnOff` semantics on Dimmer/Rollershutter
     * defaults to no actions
   * stateMappings=`<mappings>`
     * each [semantic](#semantic-extensions) mapping formatted as, based on state type: (e.g. `stateMappings="Closed=0,Open=1:100"`)
       * range => `<state>=<minValue>:<maxValue>`
       * value => `<state>=<value>`
     * [supported state semantics](#semantic-catalog)
-    * only one specific state semantic allowed per endpoint, except for `On` and `Off`
-    * no support for:
-      * any [custom semantics](#custom-semantic-catalog) on Number with defined dimension
-      * `On` and `Off` semantics on Rollershutter
+    * only one given state semantic allowed per endpoint
     * defaults to no states
 * Utterance examples:
   * *Alexa, set the `<device name>` `<capability name>` to 10.*
@@ -1756,19 +1750,23 @@ Items that represent components of a device that are characterized by numbers wi
   * *Alexa, resume the `<device name>`.* (if `Resume` action defined)
   * *Alexa, pause the `<device name>`.* (if `Pause` action defined)
   * *Alexa, stop the `<device name>`.* (if `Stop` action defined)
-  * *Alexa, turn on the `<device name>` `<capability name>`.* (if `TurnOn` action defined)
-  * *Alexa, turn off the `<device name>` `<capability name>`.* (if `TurnOff` action defined)
+  * *Alexa, turn on the `<device name>`.* (if `TurnOn` action defined)
+  * *Alexa, turn off the `<device name>`.* (if `TurnOff` action defined)
 
 <a name="togglecontroller-togglestate"></a>
 <a name="togglecomponent"></a>
 
 #### `ToggleState`
 
-Items that represent components of a device that can be toggled on or off. Multiple instances can be configured in a [group endpoint](#group-endpoint).
+Items that represent components of a device that can be toggled on or off. Multiple instances can be configured in a [group endpoint](#group-endpoint). For Number and String, the state mappings must be provided in the metadata parameters.
 
 * Supported item types:
+  * Number
+  * String
   * Switch
 * Supported metadata parameters:
+  * OFF=`<state>` (Number/String only)
+  * ON=`<state>` (Number/String only)
   * capabilityNames=`<names>`
     * each name formatted as `<@assetIdOrName>` (e.g. `capabilityNames="@Setting.Oscillate,Rotate"`)
       * predefined [asset ids](#asset-catalog)
@@ -1787,12 +1785,13 @@ Items that represent components of a device that can be toggled on or off. Multi
   * actionMappings=`<mappings>`
     * each [semantic](#semantic-extensions) mapping formatted as `<action>=ON` or `<action>=OFF` (e.g. `actionMappings="Close=OFF,Open=ON"`)
     * [supported action semantics](#semantic-catalog)
-    * only one specific action semantic allowed per endpoint
+    * only one given action semantic allowed per endpoint
+    * no support for `TurnOn` and `TurnOff` semantics
     * defaults to no actions
   * stateMappings=`<mappings>`
     * each [semantic](#semantic-extensions) mapping formatted as `<state>=ON` or `<state>=OFF` (e.g. `stateMappings="Closed=OFF,Open=ON"`)
     * [supported state semantics](#semantic-catalog)
-    * only one specific state semantic allowed per endpoint
+    * only one given state semantic allowed per endpoint
     * defaults to no states
 * Utterance examples:
   * *Alexa, turn on the `<device name>` `<capability name>`.*
@@ -2005,7 +2004,7 @@ List of custom semantic catalog defined by skill:
 Semantic Type | Identifiers
 --------------|------------
 Actions | `Pause`<br>`Resume`<br>`Stop`<br>`TurnOff`<br>`TurnOn`
-States | `Off`<br>`On`
+States |
 
 ## Unit of Measurement Catalog
 

--- a/lambda/alexa/smarthome/device/attributes/mode.js
+++ b/lambda/alexa/smarthome/device/attributes/mode.js
@@ -40,15 +40,15 @@ class Mode extends DeviceAttribute {
     const itemType = item.groupType || item.type;
 
     switch (itemType) {
-      // Number/String mode control with toggles and actions
+      // Number/String mode with switch and action controls
       case ItemType.NUMBER:
       case ItemType.STRING:
         return [
           { name: Capability.MODE_CONTROLLER, property: Property.MODE },
-          { name: Capability.TOGGLE_CONTROLLER, property: Property.TOGGLE_STATE },
+          { name: Capability.POWER_CONTROLLER, property: Property.POWER_STATE },
           { name: Capability.PLAYBACK_CONTROLLER, property: Property.PLAYBACK_ACTION }
         ];
-      // Switch mode control with actions
+      // Switch mode with action controls
       case ItemType.SWITCH:
         return [
           { name: Capability.MODE_CONTROLLER, property: Property.MODE },

--- a/lambda/alexa/smarthome/device/attributes/positionState.js
+++ b/lambda/alexa/smarthome/device/attributes/positionState.js
@@ -15,8 +15,7 @@ const { ItemType, ItemValue } = require('@openhab/constants');
 const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
 const { Capability, Property } = require('@alexa/smarthome/constants');
 const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const PlaybackAction = require('@alexa/smarthome/properties/playbackAction');
-const { AlexaActionSemantic, AlexaStateSemantic } = require('@alexa/smarthome/semantics');
+const { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } = require('@alexa/smarthome/semantics');
 const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
 const DeviceAttribute = require('./attribute');
 
@@ -170,7 +169,7 @@ class PositionState extends DeviceAttribute {
                   name: Capability.PLAYBACK_CONTROLLER,
                   property: Property.PLAYBACK_ACTION,
                   parameters: {
-                    actionMappings: { [PlaybackAction.STOP]: ItemValue.STOP }
+                    actionMappings: { [CustomActionSemantic.STOP]: ItemValue.STOP }
                   }
                 }
               ]

--- a/lambda/alexa/smarthome/device/attributes/rangeValue.js
+++ b/lambda/alexa/smarthome/device/attributes/rangeValue.js
@@ -40,19 +40,18 @@ class RangeValue extends DeviceAttribute {
     const itemType = item.groupType || item.type;
 
     switch (itemType) {
-      // Dimmer range control with commands, toggles and actions
+      // Dimmer range with command and action controls
       case ItemType.DIMMER:
         return [
           { name: Capability.RANGE_CONTROLLER, property: Property.RANGE_VALUE },
           { name: Capability.MODE_CONTROLLER, property: Property.MODE },
-          { name: Capability.TOGGLE_CONTROLLER, property: Property.TOGGLE_STATE },
           { name: Capability.PLAYBACK_CONTROLLER, property: Property.PLAYBACK_ACTION }
         ];
-      // Number range control with toggles and actions
+      // Number range with switch and action controls
       case ItemType.NUMBER:
         return [
           { name: Capability.RANGE_CONTROLLER, property: Property.RANGE_VALUE },
-          { name: Capability.TOGGLE_CONTROLLER, property: Property.TOGGLE_STATE },
+          { name: Capability.POWER_CONTROLLER, property: Property.POWER_STATE },
           { name: Capability.PLAYBACK_CONTROLLER, property: Property.PLAYBACK_ACTION }
         ];
       // Number with dimension range control
@@ -63,7 +62,7 @@ class RangeValue extends DeviceAttribute {
       case ItemType.NUMBER_TEMPERATURE:
       case ItemType.NUMBER_VOLUME:
         return [{ name: Capability.RANGE_CONTROLLER, property: Property.RANGE_VALUE }];
-      // Rollershutter range control with commands and actions
+      // Rollershutter range with command and action controls
       case ItemType.ROLLERSHUTTER:
         return [
           { name: Capability.RANGE_CONTROLLER, property: Property.RANGE_VALUE },

--- a/lambda/alexa/smarthome/device/attributes/tiltAngle.js
+++ b/lambda/alexa/smarthome/device/attributes/tiltAngle.js
@@ -15,8 +15,7 @@ const { ItemType, ItemValue } = require('@openhab/constants');
 const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
 const { Capability, Property } = require('@alexa/smarthome/constants');
 const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const PlaybackAction = require('@alexa/smarthome/properties/playbackAction');
-const { AlexaActionSemantic, AlexaStateSemantic } = require('@alexa/smarthome/semantics');
+const { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } = require('@alexa/smarthome/semantics');
 const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
 const DeviceAttribute = require('./attribute');
 
@@ -161,7 +160,7 @@ class TiltAngle extends DeviceAttribute {
                   name: Capability.PLAYBACK_CONTROLLER,
                   property: Property.PLAYBACK_ACTION,
                   parameters: {
-                    actionMappings: { [PlaybackAction.STOP]: ItemValue.STOP }
+                    actionMappings: { [CustomActionSemantic.STOP]: ItemValue.STOP }
                   }
                 }
               ]

--- a/lambda/alexa/smarthome/device/attributes/toggleState.js
+++ b/lambda/alexa/smarthome/device/attributes/toggleState.js
@@ -40,7 +40,7 @@ class ToggleState extends DeviceAttribute {
     const itemType = item.groupType || item.type;
 
     switch (itemType) {
-      // Switch toggle control with actions
+      // Switch toggle with action controls
       case ItemType.SWITCH:
         return [
           { name: Capability.TOGGLE_CONTROLLER, property: Property.TOGGLE_STATE },

--- a/lambda/alexa/smarthome/handlers/powerController.js
+++ b/lambda/alexa/smarthome/handlers/powerController.js
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemValue } = require('@openhab/constants');
 const { Interface, Property } = require('../constants');
 const { InvalidValueError } = require('../errors');
+const { PowerState } = require('../properties');
 const AlexaHandler = require('./handler');
 
 /**
@@ -70,7 +70,7 @@ class PowerController extends AlexaHandler {
       throw new InvalidValueError('No power state property defined.');
     }
 
-    const command = property.getCommand(directive.name === PowerController.TURN_ON ? ItemValue.ON : ItemValue.OFF);
+    const command = property.getCommand(directive.name === PowerController.TURN_ON ? PowerState.ON : PowerState.OFF);
 
     await openhab.sendCommand(property.item.name, command);
 

--- a/lambda/alexa/smarthome/handlers/toggleController.js
+++ b/lambda/alexa/smarthome/handlers/toggleController.js
@@ -13,6 +13,7 @@
 
 const { Interface, Property } = require('../constants');
 const { InvalidValueError } = require('../errors');
+const { ToggleState } = require('../properties');
 const AlexaHandler = require('./handler');
 
 /**
@@ -70,7 +71,7 @@ class ToggleController extends AlexaHandler {
       throw new InvalidValueError('No toggle state property defined.');
     }
 
-    const command = property.getCommand(directive.name);
+    const command = property.getCommand(directive.name === ToggleController.TURN_ON ? ToggleState.ON : ToggleState.OFF);
 
     await openhab.sendCommand(property.item.name, command);
 

--- a/lambda/alexa/smarthome/metadata.js
+++ b/lambda/alexa/smarthome/metadata.js
@@ -179,11 +179,10 @@ class AlexaMetadata {
             .filter((value, index, array) => value && array.indexOf(value) === index);
         case `array->${ParameterType.MAP}`: // ['foo=1', 'bar=2', 'baz', 'foo=3', ''] => { foo: '1', bar: '2', baz: undefined }
         case `string->${ParameterType.MAP}`: // 'foo=1,bar=2,baz,foo=3,' => { foo: '1', bar: '2', baz: undefined }
-          return Object.fromEntries(
-            (current === 'string' ? value.split(',') : value)
-              .map((value) => value.split('=', 2).map((value) => value.trim()))
-              .filter(([key], index, array) => key && array.map(([key]) => key).indexOf(key) === index)
-          );
+          return (current === 'string' ? value.split(',') : value)
+            .map((value) => value.split('=', 2).map((value) => value.trim()))
+            .filter(([key], index, array) => key && array.map(([key]) => key).indexOf(key) === index)
+            .reduce((map, [key, value]) => ({ ...map, [key]: value }), {});
         case `object->${ParameterType.RANGE}`: // { minimum: minRange, maximum: maxRange } => [minRange, maxRange]
         case `string->${ParameterType.RANGE}`: // 'minRange:maxRange:precision' => [minRange, maxRange, precision]
           return (current === 'string' ? value.split(':', 3) : Object.values(value)).map((value) => parseFloat(value));

--- a/lambda/alexa/smarthome/properties/powerState.js
+++ b/lambda/alexa/smarthome/properties/powerState.js
@@ -12,6 +12,8 @@
  */
 
 const { ItemType } = require('@openhab/constants');
+const { Parameter, ParameterType } = require('../metadata');
+const { CustomActionSemantic } = require('../semantics');
 const AlexaProperty = require('./property');
 
 /**
@@ -20,13 +22,13 @@ const AlexaProperty = require('./property');
  */
 class PowerState extends AlexaProperty {
   /**
-   * Defines on power state
+   * Defines on state
    * @type {String}
    */
   static ON = 'ON';
 
   /**
-   * Defines off power state
+   * Defines off state
    * @type {String}
    */
   static OFF = 'OFF';
@@ -37,6 +39,16 @@ class PowerState extends AlexaProperty {
    */
   get supportedItemTypes() {
     return [ItemType.COLOR, ItemType.DIMMER, ItemType.NUMBER, ItemType.STRING, ItemType.SWITCH];
+  }
+
+  /**
+   * Returns supported parameters and their type
+   * @return {Object}
+   */
+  get supportedParameters() {
+    return {
+      [Parameter.ACTION_MAPPINGS]: ParameterType.MAP
+    };
   }
 
   /**
@@ -104,6 +116,33 @@ class PowerState extends AlexaProperty {
     }
 
     return value;
+  }
+
+  /**
+   * Updates parameters
+   * @param {Object} item
+   * @param {Object} metadata
+   * @param {Object} settings
+   */
+  updateParameters(item, metadata, settings) {
+    const parameters = this.parameters;
+    // Update parameters from parent method
+    super.updateParameters(item, metadata, settings);
+
+    const actionMappings = parameters[Parameter.ACTION_MAPPINGS] || {};
+    // Iterate over action mappings parameter updating value mapping parameters based on supported action semantics
+    for (const [action, value] of Object.entries(actionMappings)) {
+      switch (action) {
+        case CustomActionSemantic.TURN_ON:
+          parameters[PowerState.ON] = value;
+          break;
+        case CustomActionSemantic.TURN_OFF:
+          parameters[PowerState.OFF] = value;
+          break;
+      }
+    }
+    // Delete action mappings parameter
+    delete parameters[Parameter.ACTION_MAPPINGS];
   }
 }
 

--- a/lambda/alexa/smarthome/semantics.js
+++ b/lambda/alexa/smarthome/semantics.js
@@ -32,20 +32,17 @@ class AlexaSemantics {
     const actionMappings = this._semantics.actionMappings;
     // Define alexa action semantic id
     const action = AlexaActionSemantic.get(name);
-    // Add mapping if action semantic id defined and not already defined in action mappings
-    if (typeof action !== 'undefined' && !actionMappings.some(({ actions }) => actions.includes(action))) {
-      // Find defined action mappings index with same directive
-      const index = actionMappings.findIndex((map) => JSON.stringify(map.directive) === JSON.stringify(directive));
-      // Update existing mapping actions list if found, otherwise add new mapping
-      if (index > -1) {
-        actionMappings[index].actions.push(action);
-      } else {
-        actionMappings.push({
-          '@type': 'ActionsToDirective',
-          actions: [action],
-          directive: directive
-        });
-      }
+    // Find defined action mappings index with same directive
+    const index = actionMappings.findIndex((map) => JSON.stringify(map.directive) === JSON.stringify(directive));
+    // Update existing mapping actions list if found, otherwise add new mapping
+    if (index > -1) {
+      actionMappings[index].actions.push(action);
+    } else {
+      actionMappings.push({
+        '@type': 'ActionsToDirective',
+        actions: [action],
+        directive: directive
+      });
     }
   }
 
@@ -58,20 +55,17 @@ class AlexaSemantics {
     const stateMappings = this._semantics.stateMappings;
     // Define alexa state semantic id
     const state = AlexaStateSemantic.get(name);
-    // Add mapping if state semantic id defined and not already defined in state mappings
-    if (typeof state !== 'undefined' && !stateMappings.some(({ states }) => states.includes(state))) {
-      // Find defined state mappings index with same range
-      const index = stateMappings.findIndex((map) => JSON.stringify(map.range) === JSON.stringify(range));
-      // Update existing mapping states list if found, otherwise add new mapping
-      if (index > -1) {
-        stateMappings[index].states.push(state);
-      } else {
-        stateMappings.push({
-          '@type': 'StatesToRange',
-          states: [state],
-          range: range
-        });
-      }
+    // Find defined state mappings index with same range
+    const index = stateMappings.findIndex((map) => JSON.stringify(map.range) === JSON.stringify(range));
+    // Update existing mapping states list if found, otherwise add new mapping
+    if (index > -1) {
+      stateMappings[index].states.push(state);
+    } else {
+      stateMappings.push({
+        '@type': 'StatesToRange',
+        states: [state],
+        range: range
+      });
     }
   }
 
@@ -84,20 +78,17 @@ class AlexaSemantics {
     const stateMappings = this._semantics.stateMappings;
     // Define alexa state semantic id
     const state = AlexaStateSemantic.get(name);
-    // Add mapping if state semantic id defined and not already defined in state mappings
-    if (typeof state !== 'undefined' && !stateMappings.some(({ states }) => states.includes(state))) {
-      // Find defined state mappings index with same value
-      const index = stateMappings.findIndex((map) => map.value === value);
-      // Update existing mapping states list if found, otherwise add new mapping
-      if (index > -1) {
-        stateMappings[index].states.push(state);
-      } else {
-        stateMappings.push({
-          '@type': 'StatesToValue',
-          states: [state],
-          value: value
-        });
-      }
+    // Find defined state mappings index with same value
+    const index = stateMappings.findIndex((map) => map.value === value);
+    // Update existing mapping states list if found, otherwise add new mapping
+    if (index > -1) {
+      stateMappings[index].states.push(state);
+    } else {
+      stateMappings.push({
+        '@type': 'StatesToValue',
+        states: [state],
+        value: value
+      });
     }
   }
 
@@ -144,14 +135,12 @@ class AlexaActionSemantic {
   static LOWER = 'Lower';
 
   /**
-   * Returns alexa semantic id for given action name if supported
+   * Returns alexa semantic id for given action name
    * @param  {String} name
    * @return {String}
    */
   static get(name) {
-    if (Object.values(this).includes(name)) {
-      return 'Alexa.Actions.' + name;
-    }
+    return 'Alexa.Actions.' + name;
   }
 }
 
@@ -172,17 +161,51 @@ class AlexaStateSemantic {
   static CLOSED = 'Closed';
 
   /**
-   * Returns alexa semantic id for given state name if supported
+   * Returns alexa semantic id for given state name
    * @param  {String} name
    * @return {String}
    */
   static get(name) {
-    if (Object.values(this).includes(name)) {
-      return 'Alexa.States.' + name;
-    }
+    return 'Alexa.States.' + name;
   }
+}
+
+/**
+ * Defines custom action semantic class
+ */
+class CustomActionSemantic {
+  /**
+   * Defines resume action semantic
+   * @type {String}
+   */
+  static RESUME = 'Resume';
+
+  /**
+   * Defines pause action semantic
+   * @type {String}
+   */
+  static PAUSE = 'Pause';
+
+  /**
+   * Defines stop action semantic
+   * @type {String}
+   */
+  static STOP = 'Stop';
+
+  /**
+   * Defines turn on action semantic
+   * @type {String}
+   */
+  static TURN_ON = 'TurnOn';
+
+  /**
+   * Defines turn off action semantic
+   * @type {String}
+   */
+  static TURN_OFF = 'TurnOff';
 }
 
 module.exports = AlexaSemantics;
 module.exports.AlexaActionSemantic = AlexaActionSemantic;
 module.exports.AlexaStateSemantic = AlexaStateSemantic;
+module.exports.CustomActionSemantic = CustomActionSemantic;

--- a/lambda/test/alexa/cases/discovery/blind.test.js
+++ b/lambda/test/alexa/cases/discovery/blind.test.js
@@ -411,9 +411,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'STOP' }
-          },
+          parameters: { STOP: 'STOP' },
           item: { name: 'windowBlindPosition1', type: 'Rollershutter' }
         },
         {
@@ -630,9 +628,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'STOP' }
-          },
+          parameters: { STOP: 'STOP' },
           item: { name: 'windowBlindTilt2', type: 'Rollershutter' }
         }
       ]

--- a/lambda/test/alexa/cases/discovery/microwave.test.js
+++ b/lambda/test/alexa/cases/discovery/microwave.test.js
@@ -48,9 +48,7 @@ module.exports = {
               value: 'RangeValue',
               config: {
                 supportedRange: '0:2:1',
-                presets: { 0: '@Value.Off', 1: '@Setting.Night', 2: '@Value.On' },
-                actionMappings: { TurnOff: '0', TurnOn: '2' },
-                stateMappings: { Off: '0', On: '1:2' }
+                presets: { 0: '@Value.Off', 1: '@Setting.Night', 2: '@Value.On' }
               }
             }
           }
@@ -87,7 +85,6 @@ module.exports = {
       capabilities: [
         'Alexa.RangeController:MicrowavePowerLevel.rangeValue',
         'Alexa.RangeController:MicrowaveSurfaceLight.rangeValue',
-        'Alexa.ToggleController:MicrowaveSurfaceLight.toggleState',
         'Alexa.ToggleController:MicrowaveTurnTable.toggleState',
         'Alexa.EndpointHealth.connectivity',
         'Alexa'
@@ -101,11 +98,6 @@ module.exports = {
           nonControllable: false
         },
         'Alexa.RangeController:MicrowaveSurfaceLight': {
-          proactivelyReported: false,
-          retrievable: true,
-          nonControllable: false
-        },
-        'Alexa.ToggleController:MicrowaveSurfaceLight': {
           proactivelyReported: false,
           retrievable: true,
           nonControllable: false
@@ -127,15 +119,6 @@ module.exports = {
           ]
         },
         'Alexa.RangeController:MicrowaveSurfaceLight': {
-          friendlyNames: [
-            'text:Surface Light:en-AU',
-            'text:Surface Light:en-CA',
-            'text:Surface Light:en-GB',
-            'text:Surface Light:en-IN',
-            'text:Surface Light:en-US'
-          ]
-        },
-        'Alexa.ToggleController:MicrowaveSurfaceLight': {
           friendlyNames: [
             'text:Surface Light:en-AU',
             'text:Surface Light:en-CA',
@@ -203,17 +186,6 @@ module.exports = {
             capabilityNames: ['Surface Light'],
             supportedRange: [0, 2, 1],
             presets: { 0: ['@Value.Off'], 1: ['@Setting.Night'], 2: ['@Value.On'] }
-          },
-          item: { name: 'MicrowaveSurfaceLight', type: 'Number' }
-        },
-        {
-          name: 'ToggleController',
-          instance: 'Toggle:MicrowaveSurfaceLight',
-          property: 'toggleState',
-          parameters: {
-            capabilityNames: ['Surface Light'],
-            actionMappings: { TurnOff: '0', TurnOn: '2' },
-            stateMappings: { Off: '0', On: '1:2' }
           },
           item: { name: 'MicrowaveSurfaceLight', type: 'Number' }
         },

--- a/lambda/test/alexa/cases/discovery/other.test.js
+++ b/lambda/test/alexa/cases/discovery/other.test.js
@@ -79,8 +79,7 @@ module.exports = {
           value: 'RangeValue',
           config: {
             supportedCommands: 'INCREASE,DECREASE',
-            actionMappings: 'TurnOff=OFF,TurnOn=ON,Stop=OFF',
-            stateMappings: 'Off=0,On=1:100'
+            actionMappings: 'Stop=OFF'
           }
         }
       }
@@ -265,31 +264,23 @@ module.exports = {
     mode1: {
       capabilities: [
         'Alexa.ModeController:mode1.mode',
-        'Alexa.ToggleController:mode1.toggleState',
+        'Alexa.PowerController.powerState',
         'Alexa.PlaybackController',
         'Alexa.EndpointHealth.connectivity',
         'Alexa'
       ],
-      displayCategories: ['OTHER'],
+      displayCategories: ['OTHER', 'SWITCH'],
       friendlyName: 'Mode 1',
       propertyFlags: {
         'Alexa.ModeController:mode1': {
           proactivelyReported: false,
           retrievable: true,
           nonControllable: false
-        },
-        'Alexa.ToggleController:mode1': {
-          proactivelyReported: false,
-          retrievable: false,
-          nonControllable: false
         }
       },
       resources: {
         'Alexa.ModeController:mode1': {
           friendlyNames: ['asset:Alexa.Setting.Mode']
-        },
-        'Alexa.ToggleController:mode1': {
-          friendlyNames: ['text:Toggle State:en-US']
         }
       },
       configuration: {
@@ -352,30 +343,15 @@ module.exports = {
           item: { name: 'mode1', type: 'String' }
         },
         {
-          name: 'ToggleController',
-          instance: 'Toggle:mode1',
-          property: 'toggleState',
-          parameters: {
-            capabilityNames: ['@Setting.ToggleState'],
-            actionMappings: {
-              Close: 'OFF',
-              Open: 'MEDIUM',
-              Lower: '(-1)',
-              Raise: '(+1)',
-              TurnOff: 'OFF',
-              TurnOn: 'MEDIUM'
-            }
-          },
+          name: 'PowerController',
+          property: 'powerState',
+          parameters: { OFF: 'OFF', ON: 'MEDIUM' },
           item: { name: 'mode1', type: 'String' }
         },
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: {
-              Stop: 'OFF'
-            }
-          },
+          parameters: { STOP: 'OFF' },
           item: { name: 'mode1', type: 'String' }
         }
       ]
@@ -442,9 +418,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'OFF' }
-          },
+          parameters: { STOP: 'OFF' },
           item: { name: 'mode2', type: 'Switch' }
         }
       ]
@@ -495,7 +469,6 @@ module.exports = {
       capabilities: [
         'Alexa.ModeController:range1.mode',
         'Alexa.RangeController:range1.rangeValue',
-        'Alexa.ToggleController:range1.toggleState',
         'Alexa.PlaybackController',
         'Alexa.EndpointHealth.connectivity',
         'Alexa'
@@ -512,11 +485,6 @@ module.exports = {
           proactivelyReported: false,
           retrievable: true,
           nonControllable: false
-        },
-        'Alexa.ToggleController:range1': {
-          proactivelyReported: false,
-          retrievable: true,
-          nonControllable: false
         }
       },
       resources: {
@@ -525,9 +493,6 @@ module.exports = {
         },
         'Alexa.RangeController:range1': {
           friendlyNames: ['text:Range Value:en-US']
-        },
-        'Alexa.ToggleController:range1': {
-          friendlyNames: ['text:Toggle State:en-US']
         }
       },
       configuration: {
@@ -568,22 +533,9 @@ module.exports = {
           item: { name: 'range1', type: 'Dimmer' }
         },
         {
-          name: 'ToggleController',
-          instance: 'Toggle:range1',
-          property: 'toggleState',
-          parameters: {
-            capabilityNames: ['@Setting.ToggleState'],
-            actionMappings: { TurnOff: 'OFF', TurnOn: 'ON' },
-            stateMappings: { Off: '0', On: '1:100' }
-          },
-          item: { name: 'range1', type: 'Dimmer' }
-        },
-        {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'OFF' }
-          },
+          parameters: { STOP: 'OFF' },
           item: { name: 'range1', type: 'Dimmer' }
         }
       ]
@@ -634,9 +586,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: '0' }
-          },
+          parameters: { STOP: '0' },
           item: { name: 'range2', type: 'Number' }
         }
       ]
@@ -746,9 +696,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'STOP' }
-          },
+          parameters: { STOP: 'STOP' },
           item: { name: 'range4', type: 'Rollershutter' }
         }
       ]

--- a/lambda/test/alexa/cases/discovery/router.test.js
+++ b/lambda/test/alexa/cases/discovery/router.test.js
@@ -69,9 +69,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Resume: 'ON', Pause: 'OFF' }
-          },
+          parameters: { RESUME: 'ON', PAUSE: 'OFF' },
           item: { name: 'guestNetwork', type: 'Switch' }
         }
       ]

--- a/lambda/test/alexa/cases/discovery/vacuumCleaner.test.js
+++ b/lambda/test/alexa/cases/discovery/vacuumCleaner.test.js
@@ -204,9 +204,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Resume: 'CLEAN', Pause: 'PAUSE', Stop: 'STOP' }
-          },
+          parameters: { RESUME: 'CLEAN', PAUSE: 'PAUSE', STOP: 'STOP' },
           item: { name: 'vacuumMode1', type: 'String' }
         },
         {
@@ -296,12 +294,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Resume: 'CLEAN', Pause: 'PAUSE', Stop: 'STOP' },
-            CLEAN: 1,
-            PAUSE: 4,
-            STOP: 5
-          },
+          parameters: { RESUME: 1, PAUSE: 4, STOP: 5 },
           item: { name: 'vacuumCleaner2', type: 'Number' }
         }
       ]
@@ -365,10 +358,7 @@ module.exports = {
         {
           name: 'PlaybackController',
           property: 'playbackAction',
-          parameters: {
-            actionMappings: { Stop: 'DOCK' },
-            DOCK: 0
-          },
+          parameters: { STOP: 0 },
           item: { name: 'vacuumCleaner3', type: 'Number' }
         }
       ]

--- a/lambda/test/alexa/cases/playbackController.test.js
+++ b/lambda/test/alexa/cases/playbackController.test.js
@@ -146,9 +146,7 @@ module.exports = [
             {
               name: 'PlaybackController',
               property: 'playbackAction',
-              parameters: {
-                actionMappings: { Resume: 'RESUME', Pause: 'PAUSE' }
-              },
+              parameters: { RESUME: 'RESUME', PAUSE: 'PAUSE' },
               item: { name: 'vacuumControl', type: 'String' }
             }
           ])
@@ -184,9 +182,7 @@ module.exports = [
             {
               name: 'PlaybackController',
               property: 'playbackAction',
-              parameters: {
-                actionMappings: { Resume: 'RESUME' }
-              },
+              parameters: { RESUME: 'RESUME' },
               item: { name: 'vacuumControl', type: 'String' }
             }
           ])

--- a/lambda/test/alexa/cases/toggleController.test.js
+++ b/lambda/test/alexa/cases/toggleController.test.js
@@ -127,8 +127,8 @@ module.exports = [
               property: 'toggleState',
               parameters: {
                 capabilityNames: ['Light'],
-                actionMappings: { TurnOff: '0', TurnOn: '2' },
-                stateMappings: { Off: '0', On: '1:3' }
+                OFF: '0',
+                ON: '2'
               },
               item: { name: 'FanLight', type: 'Number' }
             }
@@ -209,6 +209,56 @@ module.exports = [
     }
   },
   {
+    description: 'turn off toggle state number item',
+    directive: {
+      header: {
+        namespace: 'Alexa.ToggleController',
+        instance: 'Toggle:FanLight',
+        name: 'TurnOff'
+      },
+      endpoint: {
+        endpointId: 'FanLight',
+        cookie: {
+          capabilities: JSON.stringify([
+            {
+              name: 'ToggleController',
+              instance: 'Toggle:FanLight',
+              property: 'toggleState',
+              parameters: {
+                capabilityNames: ['Light'],
+                OFF: '0',
+                ON: '2'
+              },
+              item: { name: 'FanLight', type: 'Number' }
+            }
+          ])
+        }
+      }
+    },
+    items: [{ name: 'FanLight', state: '0', type: 'Number' }],
+    expected: {
+      alexa: {
+        context: {
+          properties: [
+            {
+              namespace: 'Alexa.ToggleController',
+              instance: 'Toggle:FanLight',
+              name: 'toggleState',
+              value: 'OFF'
+            }
+          ]
+        },
+        event: {
+          header: {
+            namespace: 'Alexa',
+            name: 'Response'
+          }
+        }
+      },
+      openhab: [{ name: 'FanLight', value: '0' }]
+    }
+  },
+  {
     description: 'turn off toggle state invalid value error',
     directive: {
       header: {
@@ -227,7 +277,7 @@ module.exports = [
               parameters: {
                 capabilityNames: ['Light']
               },
-              item: { name: 'FanLight', type: 'Dimmer' }
+              item: { name: 'FanLight', type: 'String' }
             }
           ])
         }


### PR DESCRIPTION
In order to simplify and align all action semantics as device based, the turn on/off custom action semantics now uses the `PowerController` interface instead of `ToggleController`. For per capability turn on/off utterance support, the `ToggleController` interface now supports Number and String item type, as long as the state mappings is provided, and can be combined with any other generic controllers as long as the item type is supported.