### PR TITLE
Avoid HTTP 302 Redirect on Root Rest Endpoint

### DIFF
--- a/lambda/openhab/index.js
+++ b/lambda/openhab/index.js
@@ -152,7 +152,7 @@ class OpenHAB {
   getRootResource() {
     const options = {
       method: 'GET',
-      uri: '/rest',
+      uri: '/rest/',
       json: true
     };
     return this._request(options);


### PR DESCRIPTION
In OpenHAB 3.1 the endpoint is ``http(s)://openhab:80/rest/`` instead of ``http(s)://openhab:80/rest``.

In my environment, this behavior has caused an error. Openhab redirected from HTTPS to HTTP. This caused a "400 Bad Request" on nginx.

This tweak avoids that redirect. I don't know if this also works with openhab 2.x.