### PR TITLE
Update camera stream handler invalid url error

### DIFF
--- a/lambda/alexa/smarthome/handlers/cameraStreamController.js
+++ b/lambda/alexa/smarthome/handlers/cameraStreamController.js
@@ -13,7 +13,7 @@
 
 const { parseUrl } = require('@root/utils');
 const { Interface, Property } = require('../constants');
-const { InvalidValueError } = require('../errors');
+const { CurrentModeNotSupportedError } = require('../errors');
 const AlexaHandler = require('./handler');
 
 /**
@@ -61,9 +61,9 @@ class CameraStreamController extends AlexaHandler {
     // Determine camera stream url based on item current state
     const streamUrl = await openhab.getItemState(item.name).then((state) => parseUrl(state, proxyBaseUrl));
 
-    // Throw invalid value error if camera stream url not defined, not https protocol or has non-standard port
+    // Throw current mode not supported error if stream url not defined, not https protocol or has non-standard port
     if (!streamUrl || streamUrl.protocol !== 'https:' || streamUrl.port) {
-      throw new InvalidValueError('Could not determine a valid camera stream URL');
+      throw new CurrentModeNotSupportedError('Invalid camera stream URL', { currentDeviceMode: 'NOT_PROVISIONED' });
     }
 
     // Return directive response including camera stream and image information

--- a/lambda/test/alexa/cases/cameraStreamController.test.js
+++ b/lambda/test/alexa/cases/cameraStreamController.test.js
@@ -110,8 +110,9 @@ module.exports = [
             name: 'ErrorResponse'
           },
           payload: {
-            type: 'INVALID_VALUE',
-            message: 'Could not determine a valid camera stream URL'
+            type: 'NOT_SUPPORTED_IN_CURRENT_MODE',
+            message: 'Invalid camera stream URL',
+            currentDeviceMode: 'NOT_PROVISIONED'
           }
         }
       }


### PR DESCRIPTION
Based on the [Alexa API documentation](https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-camerastreamcontroller.html#initializecamerastreams-error-handling).