### PR TITLE
Improve discovery endpoint cookie limitation

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -634,6 +634,7 @@ If paired with [`TiltAngle`](#tiltangle), the primary controls (open/close/stop)
     * defaults to `position`
   * presets=`<presets>`
     * each preset formatted as `<presetValue>=<@assetIdOrName1>:...` (e.g. `presets="20=Morning,60=Afternoon,80=Evening:@Setting.Night"`)
+    * limited to a maximum of 150 presets
     * predefined [asset ids](#asset-catalog)
     * defaults to item state description options `presets="value1=label1,..."` if defined, otherwise no presets
   * language=`<code>`
@@ -681,6 +682,7 @@ If paired with [`PositionState`](#positionstate), the primary controls (open/clo
     * defaults to `position`
   * presets=`<presets>`
     * each preset formatted as `<presetValue>=<@assetIdOrName1>:...` (e.g. `presets="20=Morning,60=Afternoon,80=Evening:@Setting.Night"`)
+    * limited to a maximum of 150 presets
     * predefined [asset ids](#asset-catalog)
     * defaults to item state description options `presets="value1=label1,..."` if defined, otherwise no presets
   * language=`<code>`
@@ -767,7 +769,7 @@ Items that represent an input source (e.g. "HDMI 1" or "TUNER" on a stereo).
 * Supported metadata parameters:
   * supportedInputs=`<inputs>`
     * each input formatted as `<inputValue>=<inputName1>:...` (e.g. `supportedInputs="HDMI1=Cable:Comcast,HDMI2=Kodi"`)
-    * requires at least two inputs to be specified
+    * requires at least two inputs to be specified with a maximum of 150
     * input value used as name if not provided (e.g. `supportedInputs="HDMI1,DVD"` <=> `supportedInputs="HDMI1=HDMI1,DVD=DVD`)
     * defaults to item state description options `supportedInputs="value1=label1,..."`, if defined, otherwise no supported inputs
   * language=`<code>`
@@ -1656,7 +1658,7 @@ Items that represent components of a device that have more than one setting. Mul
     * defaults to item state description read only property if defined, otherwise false
   * supportedModes=`<modes>`
     * each mode formatted as `<mode>=<@assetIdOrName1>:...` (e.g. `supportedModes="0=Cold:Cool,1=Warm,2=Hot"`)
-    * requires at least two modes to be specified
+    * requires at least two modes to be specified with a maximum of 150
     * shortened format available for string-based modes by either leaving the first element empty or not providing the mode name at all (e.g. `supportedModes="Normal=:Cottons,Whites"` <=> `supportedModes="Normal=Normal:Cottons,Whites=Whites`)
     * defaults to item state description options `supportedModes="value1=label1,..."`, if defined, otherwise no supported modes
   * ordered=`<boolean>`
@@ -1729,6 +1731,7 @@ Items that represent components of a device that are characterized by numbers wi
     * defaults to item state description min, max & step values, if defined, otherwise `"0:100:1"` (Dimmer/Rollershutter); `"0:10:1"` (Number)
   * presets=`<presets>`
     * each preset formatted as `<presetValue>=<@assetIdOrName1>:...` (e.g. `presets="1=@Value.Low:Lowest,10=@Value.High:Highest"`)
+    * limited to a maximum of 150 presets
     * requires to be a multiple of the supported range precision
     * defaults to item state description options `presets="value1=label1,..."` if defined, otherwise no presets
   * unitOfMeasure=`<unitId>`

--- a/lambda/alexa/smarthome/directive.js
+++ b/lambda/alexa/smarthome/directive.js
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+const { decompressJSON } = require('@root/utils');
 const { Interface } = require('./constants');
 const AlexaEndpoint = require('./endpoint');
 const AlexaResponse = require('./response');
@@ -136,7 +137,7 @@ class AlexaDirective {
       ...(this.hasEndpoint && {
         endpointId: this._directive.endpoint.endpointId,
         cookie: Object.entries(this._directive.endpoint.cookie || {}).reduce(
-          (cookie, [key, value]) => ({ ...cookie, [key]: JSON.parse(value) }),
+          (cookie, [key, value]) => ({ ...cookie, [key]: decompressJSON(value) }),
           {}
         ),
         payload: this.payload

--- a/lambda/alexa/smarthome/endpoint.js
+++ b/lambda/alexa/smarthome/endpoint.js
@@ -12,7 +12,7 @@
  */
 
 const { v5: uuidv5 } = require('uuid');
-const { stripPunctuation } = require('@root/utils');
+const { compressJSON, decompressJSON, stripPunctuation } = require('@root/utils');
 const { ItemType } = require('@openhab/constants');
 const AlexaCapabilities = require('./capabilities');
 const AlexaDisplayCategory = require('./category');
@@ -270,7 +270,7 @@ class AlexaEndpoint {
    */
   getCookie() {
     const capabilities = this.capabilities.map((capability) => capability.toJSON()).flat();
-    return { ...(capabilities.length > 0 && { capabilities: JSON.stringify(capabilities) }) };
+    return { ...(capabilities.length > 0 && { capabilities: compressJSON(capabilities) }) };
   }
 
   /**
@@ -513,7 +513,7 @@ class AlexaEndpoint {
     // Load directive endpoint cookie capabilities if defined,
     //  otherwise load property map for backward compatibility if present
     if (cookie.capabilities) {
-      endpoint.loadCapabilities(JSON.parse(cookie.capabilities));
+      endpoint.loadCapabilities(decompressJSON(cookie.capabilities));
     } else if (cookie.propertyMap) {
       endpoint.loadPropertyMap(JSON.parse(cookie.propertyMap));
     }

--- a/lambda/alexa/smarthome/properties/mode.js
+++ b/lambda/alexa/smarthome/properties/mode.js
@@ -23,6 +23,12 @@ const Generic = require('./generic');
  */
 class Mode extends Generic {
   /**
+   * Defines supported modes limit
+   * @type {Number}
+   */
+  static #SUPPORTED_MODES_LIMIT = 150;
+
+  /**
    * Returns supported item types
    * @return {Array}
    */
@@ -199,6 +205,7 @@ class Mode extends Generic {
         )
       ])
       .filter(([, labels]) => labels.length > 0)
+      .slice(0, Mode.#SUPPORTED_MODES_LIMIT)
       .reduce((modes, [mode, labels]) => ({ ...modes, [mode]: labels }), undefined);
 
     // Delete supported commands parameter

--- a/lambda/alexa/smarthome/properties/rangeValue.js
+++ b/lambda/alexa/smarthome/properties/rangeValue.js
@@ -23,6 +23,12 @@ const Generic = require('./generic');
  */
 class RangeValue extends Generic {
   /**
+   * Defines presets limit
+   * @type {Number}
+   */
+  static #PRESETS_LIMIT = 150;
+
+  /**
    * Returns supported item types
    * @return {Array}
    */
@@ -206,6 +212,7 @@ class RangeValue extends Generic {
           preset % this.supportedRange[2] === 0 &&
           labels.length > 0
       )
+      .slice(0, RangeValue.#PRESETS_LIMIT)
       .reduce((presets, [preset, labels]) => ({ ...presets, [preset]: labels }), undefined);
 
     // Define unit of measure as follow:

--- a/lambda/test/alexa/cases/alexa.test.js
+++ b/lambda/test/alexa/cases/alexa.test.js
@@ -84,6 +84,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
+          // backward compatibility cookie capabilities uncompressed load test
           capabilities: JSON.stringify([
             {
               name: 'ColorController',
@@ -139,7 +140,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -152,7 +153,7 @@ module.exports = [
               parameters: {},
               item: { name: 'colorTemperature', type: 'Dimmer', binding: 'hue' }
             }
-          ])
+          ]
         }
       }
     },
@@ -194,7 +195,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -207,7 +208,7 @@ module.exports = [
               parameters: { range: [2700, 6500], retrievable: false },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -246,7 +247,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -259,7 +260,7 @@ module.exports = [
               parameters: { range: [2700, 6500] },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -297,7 +298,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -310,7 +311,7 @@ module.exports = [
               parameters: { binding: 'hue' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -397,14 +398,14 @@ module.exports = [
       endpoint: {
         endpointId: 'contact',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ContactSensor',
               property: 'detectionState',
               parameters: {},
               item: { name: 'contact', type: 'Contact' }
             }
-          ])
+          ]
         }
       }
     },
@@ -439,14 +440,14 @@ module.exports = [
       endpoint: {
         endpointId: 'contact',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ContactSensor',
               property: 'detectionState',
               parameters: { inverted: true },
               item: { name: 'contact', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -481,14 +482,14 @@ module.exports = [
       endpoint: {
         endpointId: 'motion',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'MotionSensor',
               property: 'detectionState',
               parameters: { inverted: true },
               item: { name: 'motion', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -523,14 +524,14 @@ module.exports = [
       endpoint: {
         endpointId: 'temperature',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'TemperatureSensor',
               property: 'temperature',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'temperature', type: 'Number:Temperature' }
             }
-          ])
+          ]
         }
       }
     },
@@ -623,7 +624,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -663,7 +664,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -711,7 +712,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -735,7 +736,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -781,7 +782,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -805,7 +806,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -851,7 +852,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
@@ -875,7 +876,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -921,7 +922,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSensor',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'MotionSensor',
               property: 'detectionState',
@@ -939,7 +940,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -987,7 +988,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -1018,7 +1019,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -1065,7 +1066,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSwitch',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -1089,7 +1090,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -1135,7 +1136,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gTelevision',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -1159,7 +1160,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -1205,7 +1206,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
@@ -1229,7 +1230,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },
@@ -1278,7 +1279,7 @@ module.exports = [
       endpoint: {
         endpointId: 'switch1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
@@ -1290,7 +1291,7 @@ module.exports = [
               property: 'connectivity',
               parameters: {}
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/brightnessController.test.js
+++ b/lambda/test/alexa/cases/brightnessController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: {},
               item: { name: 'light1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: {},
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -118,14 +118,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: {},
               item: { name: 'light1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -169,14 +169,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: {},
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -220,14 +220,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: { retrievable: false },
               item: { name: 'light1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -259,14 +259,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'BrightnessController',
               property: 'brightness',
               parameters: {},
               item: { name: 'light1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/cameraStreamController.test.js
+++ b/lambda/test/alexa/cases/cameraStreamController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'cameraStream',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'CameraStreamController',
               property: 'cameraStream',
               parameters: { proxyBaseUrl: 'https://openhab.myserver.tld' },
               item: { name: 'cameraStream', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -79,7 +79,7 @@ module.exports = [
       endpoint: {
         endpointId: 'cameraStream',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'CameraStreamController',
               property: 'cameraStream',
@@ -91,7 +91,7 @@ module.exports = [
               },
               item: { name: 'cameraStream', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -141,14 +141,14 @@ module.exports = [
       endpoint: {
         endpointId: 'cameraStream',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'CameraStreamController',
               property: 'cameraStream',
               parameters: { proxyBaseUrl: 'https://openhab.myserver.tld:8443' },
               item: { name: 'cameraStream', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/channelController.test.js
+++ b/lambda/test/alexa/cases/channelController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: {},
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -75,14 +75,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { supportsChannelNumber: true },
               item: { name: 'channel', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -128,14 +128,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { foo: 'FOO', bar: 'BAR', baz: 'BAZ' } },
               item: { name: 'channel', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -170,14 +170,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { range: [100, 499] },
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -216,14 +216,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { 12: 'FOO', 34: 'BAR', 56: 'BAZ' } },
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -270,14 +270,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { foo: 'FOO', bar: 'BAR', baz: 'BAZ' } },
               item: { name: 'channel', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -323,14 +323,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { 12: 'FOO', 34: 'BAR' } },
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -365,14 +365,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { foo: 'FOO', bar: 'BAR', baz: 'BAZ' } },
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -407,14 +407,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channelStep',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channelStep',
               parameters: { CHANNEL_UP: 'CHUP', CHANNEL_DOWN: 'CHDOWN' },
               item: { name: 'channelStep', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -449,14 +449,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: {},
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -502,14 +502,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { foo: 'FOO', bar: 'BAR', baz: 'BAZ' } },
               item: { name: 'channel', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -555,14 +555,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channelStep',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channelStep',
               parameters: { CHANNEL_UP: 'CHUP', CHANNEL_DOWN: 'CHDOWN' },
               item: { name: 'channelStep', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -594,14 +594,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channelStep',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channelStep',
               parameters: { CHANNEL_UP: 'CHUP', CHANNEL_DOWN: 'CHDOWN' },
               item: { name: 'channelStep', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -633,14 +633,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { channelMappings: { foo: 'FOO', bar: 'BAR' } },
               item: { name: 'channel', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -673,14 +673,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: { retrievable: false },
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -712,14 +712,14 @@ module.exports = [
       endpoint: {
         endpointId: 'channel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ChannelController',
               property: 'channel',
               parameters: {},
               item: { name: 'channel', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/colorController.test.js
+++ b/lambda/test/alexa/cases/colorController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
               parameters: {},
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -81,14 +81,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
               parameters: {},
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -140,14 +140,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
               parameters: { retrievable: false },
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -186,7 +186,7 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -199,7 +199,7 @@ module.exports = [
               parameters: { requiresSetColorReset: true },
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/colorTemperatureController.test.js
+++ b/lambda/test/alexa/cases/colorTemperatureController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { range: [2700, 6500] },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'hue' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -118,14 +118,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'hue:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -166,14 +166,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'lifx' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -214,14 +214,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'lifx:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -262,14 +262,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'milight' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -310,14 +310,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'milight:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -358,14 +358,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'tradfri' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -406,14 +406,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'tradfri:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -454,14 +454,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'tplinksmarthome' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -502,14 +502,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'tplinksmarthome:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -550,14 +550,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'yeelight' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -598,14 +598,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { binding: 'yeelight:white' },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -646,14 +646,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: {},
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -694,7 +694,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -707,7 +707,7 @@ module.exports = [
               parameters: { retrievable: false },
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -741,14 +741,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { range: [2200, 4000] },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -784,14 +784,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: {},
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -832,14 +832,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { increment: 10 },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -880,14 +880,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: {},
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -928,14 +928,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: {},
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -976,14 +976,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { increment: 10 },
               item: { name: 'colorTemperature', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -1024,14 +1024,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { increment: 900 },
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -1072,14 +1072,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: { retrievable: false },
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -1108,14 +1108,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorTemperatureController',
               property: 'colorTemperatureInKelvin',
               parameters: {},
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -1145,7 +1145,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gColorLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ColorController',
               property: 'color',
@@ -1158,7 +1158,7 @@ module.exports = [
               parameters: {},
               item: { name: 'colorTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/equalizerController.test.js
+++ b/lambda/test/alexa/cases/equalizerController.test.js
@@ -22,7 +22,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
@@ -49,7 +49,7 @@ module.exports = [
               parameters: { supportedModes: ['MOVIE', 'TV'] },
               item: { name: 'equalizerMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -114,7 +114,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -129,7 +129,7 @@ module.exports = [
               parameters: { range: [-5, 5] },
               item: { name: 'equalizerTreble', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -183,7 +183,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -191,7 +191,7 @@ module.exports = [
               parameters: { range: [-5, 5], increment: 3 },
               item: { name: 'equalizerBass', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -240,7 +240,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -248,7 +248,7 @@ module.exports = [
               parameters: { range: [-5, 5] },
               item: { name: 'equalizerBass', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -297,7 +297,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -305,7 +305,7 @@ module.exports = [
               parameters: {},
               item: { name: 'equalizerBass', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -354,7 +354,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -362,7 +362,7 @@ module.exports = [
               parameters: {},
               item: { name: 'equalizerBass', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -411,7 +411,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -419,7 +419,7 @@ module.exports = [
               parameters: { range: [-5, 5], retrievable: false },
               item: { name: 'equalizerBass', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -451,7 +451,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -459,7 +459,7 @@ module.exports = [
               parameters: { range: [-5, 5] },
               item: { name: 'equalizerBass', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -492,7 +492,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'bands',
@@ -500,7 +500,7 @@ module.exports = [
               parameters: { range: [-5, 5], defaultLevel: 1 },
               item: { name: 'equalizerBass', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -546,14 +546,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'mode',
               parameters: { supportedModes: ['MOVIE', 'TV'] },
               item: { name: 'equalizerMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -594,14 +594,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'EqualizerController',
               property: 'mode',
               parameters: { supportedModes: ['MOVIE', 'TV'] },
               item: { name: 'equalizerMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/inputController.test.js
+++ b/lambda/test/alexa/cases/inputController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'tvSource',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'InputController',
               property: 'input',
               parameters: { supportedInputs: ['HDMI 1', 'TV'] },
               item: { name: 'tvSource', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'tvSource',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'InputController',
               property: 'input',
               parameters: { supportedInputs: ['HDMI 1', 'TV'] },
               item: { name: 'tvSource', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/lockController.test.js
+++ b/lambda/test/alexa/cases/lockController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
               parameters: {},
               item: { name: 'doorLock', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -67,14 +67,14 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
               parameters: { inverted: true },
               item: { name: 'doorLock', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -112,14 +112,14 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
               parameters: {},
               item: { name: 'doorLock', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -157,14 +157,14 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
               parameters: { inverted: true },
               item: { name: 'doorLock', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -202,7 +202,7 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
@@ -216,7 +216,7 @@ module.exports = [
               parameters: {},
               item: { name: 'currentDoorLock', type: 'Contact' }
             }
-          ])
+          ]
         }
       }
     },
@@ -254,7 +254,7 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
@@ -268,7 +268,7 @@ module.exports = [
               parameters: {},
               item: { name: 'currentDoorLock', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -306,7 +306,7 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
@@ -320,7 +320,7 @@ module.exports = [
               parameters: {},
               item: { name: 'currentDoorLock', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },
@@ -358,7 +358,7 @@ module.exports = [
       endpoint: {
         endpointId: 'doorLock',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'LockController',
               property: 'lockState',
@@ -372,7 +372,7 @@ module.exports = [
               parameters: { LOCKED: 1, UNLOCKED: 2, JAMMED: 42 },
               item: { name: 'currentDoorLock', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/modeController.test.js
+++ b/lambda/test/alexa/cases/modeController.test.js
@@ -23,7 +23,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashCycle',
@@ -38,7 +38,7 @@ module.exports = [
               },
               item: { name: 'WashCycle', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -81,7 +81,7 @@ module.exports = [
       endpoint: {
         endpointId: 'GarageDoor',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'OpenState',
@@ -96,7 +96,7 @@ module.exports = [
               },
               item: { name: 'GarageDoor', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -139,7 +139,7 @@ module.exports = [
       endpoint: {
         endpointId: 'GarageDoor',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'OpenState',
@@ -160,7 +160,7 @@ module.exports = [
               parameters: {},
               item: { name: 'ObstacleAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -225,7 +225,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashCycle',
@@ -240,7 +240,7 @@ module.exports = [
               },
               item: { name: 'WashCycle', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -273,7 +273,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashTemperature',
@@ -289,7 +289,7 @@ module.exports = [
               },
               item: { name: 'WashTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -366,7 +366,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashTemperature',
@@ -383,7 +383,7 @@ module.exports = [
               },
               item: { name: 'WashTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -416,7 +416,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashTemperature',
@@ -432,7 +432,7 @@ module.exports = [
               },
               item: { name: 'WashTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -466,7 +466,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gWasher',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WashTemperature',
@@ -482,7 +482,7 @@ module.exports = [
               },
               item: { name: 'WashTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -515,7 +515,7 @@ module.exports = [
       endpoint: {
         endpointId: 'WindowBlind',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'Mode:WindowBlind',
@@ -543,7 +543,7 @@ module.exports = [
               },
               item: { name: 'WindowBlind', type: 'Rollershutter' }
             }
-          ])
+          ]
         }
       }
     },
@@ -579,7 +579,7 @@ module.exports = [
       endpoint: {
         endpointId: 'GarageDoor',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ModeController',
               instance: 'OpenState',
@@ -607,7 +607,7 @@ module.exports = [
               },
               item: { name: 'CurrentGarageDoor', type: 'Contact' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/networkingAccessController.test.js
+++ b/lambda/test/alexa/cases/networkingAccessController.test.js
@@ -22,7 +22,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gComputer',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'NetworkingConnectedDevice',
               property: 'connectedDevice',
@@ -39,7 +39,7 @@ module.exports = [
               parameters: {},
               item: { name: 'networkAccess', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -80,7 +80,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gComputer',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'NetworkingConnectedDevice',
               property: 'connectedDevice',
@@ -99,7 +99,7 @@ module.exports = [
               },
               item: { name: 'networkAccess', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -140,7 +140,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gComputer',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'NetworkingConnectedDevice',
               property: 'connectedDevice',
@@ -159,7 +159,7 @@ module.exports = [
               },
               item: { name: 'networkAccess', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/percentageController.test.js
+++ b/lambda/test/alexa/cases/percentageController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: {},
               item: { name: 'device1', type: 'Rollershutter' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -118,14 +118,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -169,14 +169,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: {},
               item: { name: 'device1', type: 'Rollershutter' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -220,14 +220,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: { retrievable: false },
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -259,14 +259,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PercentageController',
               property: 'percentage',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/playbackController.test.js
+++ b/lambda/test/alexa/cases/playbackController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PlaybackController',
               property: 'playback',
               parameters: {},
               item: { name: 'speakerPlayer', type: 'Player' }
             }
-          ])
+          ]
         }
       }
     },
@@ -60,7 +60,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PlaybackController',
               property: 'playback',
@@ -73,7 +73,7 @@ module.exports = [
               parameters: {},
               item: { name: 'speakerPlayerStop', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -104,7 +104,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PlaybackController',
               property: 'playback',
@@ -117,7 +117,7 @@ module.exports = [
               parameters: { inverted: true },
               item: { name: 'speakerPlayerStop', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -148,14 +148,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PlaybackController',
               property: 'playbackAction',
               parameters: { RESUME: 'RESUME', PAUSE: 'PAUSE' },
               item: { name: 'vacuumControl', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },
@@ -186,14 +186,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PlaybackController',
               property: 'playbackAction',
               parameters: { RESUME: 'RESUME' },
               item: { name: 'vacuumControl', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/powerController.test.js
+++ b/lambda/test/alexa/cases/powerController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: {},
               item: { name: 'light1', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -67,14 +67,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: {},
               item: { name: 'light1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       }
     },
@@ -112,14 +112,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: { OFF: '0', ON: '10' },
               item: { name: 'device1', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -157,14 +157,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: { retrievable: false },
               item: { name: 'light1', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -195,14 +195,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: {},
               item: { name: 'light1', type: 'Color' }
             }
-          ])
+          ]
         }
       }
     },
@@ -240,14 +240,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: { OFF: 'off', ON: 'on' },
               item: { name: 'device1', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },
@@ -285,14 +285,14 @@ module.exports = [
       endpoint: {
         endpointId: 'light1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: {},
               item: { name: 'light1', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -321,14 +321,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerController',
               property: 'powerState',
               parameters: { OFF: 'OFF', ON: 'LOW' },
               item: { name: 'device1', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/powerLevelController.test.js
+++ b/lambda/test/alexa/cases/powerLevelController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerLevelController',
               property: 'powerLevel',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerLevelController',
               property: 'powerLevel',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -121,14 +121,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerLevelController',
               property: 'powerLevel',
               parameters: { retrievable: false },
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -160,14 +160,14 @@ module.exports = [
       endpoint: {
         endpointId: 'device1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'PowerLevelController',
               property: 'powerLevel',
               parameters: {},
               item: { name: 'device1', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/rangeController.test.js
+++ b/lambda/test/alexa/cases/rangeController.test.js
@@ -23,7 +23,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -34,7 +34,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -77,7 +77,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -88,7 +88,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -131,7 +131,7 @@ module.exports = [
       endpoint: {
         endpointId: 'WindowBlind',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:WindowBlind',
@@ -142,7 +142,7 @@ module.exports = [
               },
               item: { name: 'WindowBlind', type: 'Rollershutter' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -216,7 +216,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -227,7 +227,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -274,7 +274,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -286,7 +286,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -365,7 +365,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -377,7 +377,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -411,7 +411,7 @@ module.exports = [
       endpoint: {
         endpointId: 'BasementFan',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'RangeController',
               instance: 'Range:BasementFan',
@@ -422,7 +422,7 @@ module.exports = [
               },
               item: { name: 'BasementFan', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/sceneController.test.js
+++ b/lambda/test/alexa/cases/sceneController.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'scene1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SceneController',
               property: 'scene',
               parameters: {},
               item: { name: 'scene1', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -65,14 +65,14 @@ module.exports = [
       endpoint: {
         endpointId: 'scene1',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SceneController',
               property: 'scene',
               parameters: {},
               item: { name: 'scene1', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/securityPanelController.test.js
+++ b/lambda/test/alexa/cases/securityPanelController.test.js
@@ -22,7 +22,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -43,7 +43,7 @@ module.exports = [
               parameters: { inverted: true },
               item: { name: 'BurglaryAlarm', type: 'Contact' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -97,7 +97,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -113,7 +113,7 @@ module.exports = [
               parameters: {},
               item: { name: 'AlarmAlert', type: 'Contact' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -161,7 +161,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -174,7 +174,7 @@ module.exports = [
               },
               item: { name: 'ArmMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -254,14 +254,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'burglaryAlarm',
               parameters: {},
               item: { name: 'BurglaryAlarm', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -293,7 +293,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -304,7 +304,7 @@ module.exports = [
               },
               item: { name: 'ArmMode', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -336,7 +336,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -345,7 +345,7 @@ module.exports = [
               },
               item: { name: 'ArmMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -378,7 +378,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -393,7 +393,7 @@ module.exports = [
               parameters: { inverted: true },
               item: { name: 'ZonesAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -429,7 +429,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -444,7 +444,7 @@ module.exports = [
               parameters: {},
               item: { name: 'ReadyAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -480,7 +480,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -495,7 +495,7 @@ module.exports = [
               parameters: {},
               item: { name: 'AlarmAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -531,7 +531,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -546,7 +546,7 @@ module.exports = [
               parameters: {},
               item: { name: 'TroubleAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -582,7 +582,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -604,7 +604,7 @@ module.exports = [
               parameters: {},
               item: { name: 'FireAlarm', type: 'Contact' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -659,7 +659,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -668,7 +668,7 @@ module.exports = [
               },
               item: { name: 'ArmMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -740,14 +740,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'burglaryAlarm',
               parameters: {},
               item: { name: 'BurglaryAlarm', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -777,7 +777,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -787,7 +787,7 @@ module.exports = [
               },
               item: { name: 'ArmMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -822,7 +822,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gSecurityPanel',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -837,7 +837,7 @@ module.exports = [
               parameters: {},
               item: { name: 'ReadyAlert', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -868,7 +868,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gAlarmSystem',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'SecurityPanelController',
               property: 'armState',
@@ -901,7 +901,7 @@ module.exports = [
               parameters: { inverted: true },
               item: { name: 'WaterAlarm', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/cases/speaker.test.js
+++ b/lambda/test/alexa/cases/speaker.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: {},
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -70,14 +70,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'muted',
               parameters: {},
               item: { name: 'speakerMute', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -109,14 +109,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: {},
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -161,14 +161,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: {},
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -213,14 +213,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: { increment: 5 },
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -265,14 +265,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: { increment: 5 },
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -317,14 +317,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'muted',
               parameters: {},
               item: { name: 'speakerMute', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -357,14 +357,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: { increment: 5, retrievable: false },
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -397,14 +397,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: { increment: 5 },
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -438,14 +438,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'muted',
               parameters: {},
               item: { name: 'speakerMute', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -486,14 +486,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'muted',
               parameters: { inverted: true },
               item: { name: 'speakerMute', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -534,14 +534,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'Speaker',
               property: 'volume',
               parameters: {},
               item: { name: 'speakerVolume', type: 'Dimmer' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/stepSpeaker.test.js
+++ b/lambda/test/alexa/cases/stepSpeaker.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'volume',
               parameters: { VOLUME_UP: 'VOLUP', VOLUME_DOWN: 'VOLDOWN' },
               item: { name: 'stepSpeakerVolume', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -67,14 +67,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'volume',
               parameters: { VOLUME_UP: 'VOLUP', VOLUME_DOWN: 'VOLDOWN' },
               item: { name: 'stepSpeakerVolume', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -109,14 +109,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'volume',
               parameters: { VOLUME_UP: 'VOLUP', VOLUME_DOWN: 'VOLDOWN' },
               item: { name: 'stepSpeakerVolume', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -151,14 +151,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'muted',
               parameters: { MUTE: 'MUTE' },
               item: { name: 'stepSpeakerMute', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -191,14 +191,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'muted',
               parameters: { MUTE: 'MUTE' },
               item: { name: 'stepSpeakerMute', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -232,14 +232,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gStepSpeaker',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'StepSpeaker',
               property: 'volume',
               parameters: { VOLUME_UP: 'VOLUP', VOLUME_DOWN: 'VOLDOWN' },
               item: { name: 'stepSpeakerVolume', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/thermostatControllerMode.test.js
+++ b/lambda/test/alexa/cases/thermostatControllerMode.test.js
@@ -22,14 +22,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: '0', HEAT: '1', COOL: '2', AUTO: '3' },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -72,14 +72,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: 0, HEAT: 1, COOL: 2, AUTO: 3 },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -122,14 +122,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { binding: 'nest' },
               item: { name: 'thermostatMode', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -172,14 +172,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -213,14 +213,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: '0', HEAT: '1', COOL: '2', AUTO: '3' },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -254,7 +254,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -267,7 +267,7 @@ module.exports = [
               parameters: {},
               item: { name: 'thermostatHold', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -309,7 +309,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -322,7 +322,7 @@ module.exports = [
               parameters: {},
               item: { name: 'thermostatHold', type: 'String' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -364,7 +364,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'TemperatureSensor',
               property: 'temperature',
@@ -383,7 +383,7 @@ module.exports = [
               parameters: { inverted: true },
               item: { name: 'thermostatHold', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -434,7 +434,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -447,7 +447,7 @@ module.exports = [
               parameters: {},
               item: { name: 'thermostatHold', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -479,14 +479,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: '0', HEAT: '1', COOL: '2', AUTO: '3' },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {}
@@ -516,7 +516,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -529,7 +529,7 @@ module.exports = [
               parameters: {},
               item: { name: 'thermostatHold', type: 'Switch' }
             }
-          ])
+          ]
         }
       },
       payload: {}

--- a/lambda/test/alexa/cases/thermostatControllerTemperature.test.js
+++ b/lambda/test/alexa/cases/thermostatControllerTemperature.test.js
@@ -22,7 +22,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
@@ -41,7 +41,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -120,7 +120,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'upperSetpoint',
@@ -133,7 +133,7 @@ module.exports = [
               parameters: { scale: 'CELSIUS' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -194,7 +194,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'upperSetpoint',
@@ -207,7 +207,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -268,7 +268,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'upperSetpoint',
@@ -281,7 +281,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT', comfortRange: 5 },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -342,7 +342,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -375,7 +375,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'ecoLowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -449,7 +449,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -468,7 +468,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -525,7 +525,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -544,7 +544,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -601,7 +601,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -620,7 +620,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -679,7 +679,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -704,7 +704,7 @@ module.exports = [
               parameters: { scale: 'CELSIUS' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -762,7 +762,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -787,7 +787,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -845,14 +845,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -891,14 +891,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -943,7 +943,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -956,7 +956,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1030,14 +1030,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: '0', HEAT: '1', COOL: '2', AUTO: '3' },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1073,7 +1073,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -1098,7 +1098,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1138,7 +1138,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -1163,7 +1163,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1207,7 +1207,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'upperSetpoint',
@@ -1220,7 +1220,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1263,14 +1263,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1320,7 +1320,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'upperSetpoint',
@@ -1333,7 +1333,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1396,7 +1396,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -1415,7 +1415,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'lowTargetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1473,7 +1473,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -1492,7 +1492,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1552,14 +1552,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'CELSIUS' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1609,14 +1609,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1666,14 +1666,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT', setpointRange: [60, 90] },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1723,7 +1723,7 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
@@ -1736,7 +1736,7 @@ module.exports = [
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1810,14 +1810,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'thermostatMode',
               parameters: { OFF: '0', HEAT: '1', COOL: '2', AUTO: '3' },
               item: { name: 'thermostatMode', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1853,14 +1853,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT', retrievable: false },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {
@@ -1895,14 +1895,14 @@ module.exports = [
       endpoint: {
         endpointId: 'gThermostat',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ThermostatController',
               property: 'targetSetpoint',
               parameters: { scale: 'FAHRENHEIT' },
               item: { name: 'targetTemperature', type: 'Number' }
             }
-          ])
+          ]
         }
       },
       payload: {

--- a/lambda/test/alexa/cases/toggleController.test.js
+++ b/lambda/test/alexa/cases/toggleController.test.js
@@ -23,7 +23,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanOscillate',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanOscillate',
@@ -33,7 +33,7 @@ module.exports = [
               },
               item: { name: 'FanOscillate', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -73,7 +73,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanOscillate',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanOscillate',
@@ -84,7 +84,7 @@ module.exports = [
               },
               item: { name: 'FanOscillate', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -124,7 +124,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanLight',
@@ -136,7 +136,7 @@ module.exports = [
               },
               item: { name: 'FanLight', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -176,7 +176,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanOscillate',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanOscillate',
@@ -187,7 +187,7 @@ module.exports = [
               },
               item: { name: 'FanOscillate', type: 'Switch' }
             }
-          ])
+          ]
         }
       }
     },
@@ -227,7 +227,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanLight',
@@ -239,7 +239,7 @@ module.exports = [
               },
               item: { name: 'FanLight', type: 'Number' }
             }
-          ])
+          ]
         }
       }
     },
@@ -279,7 +279,7 @@ module.exports = [
       endpoint: {
         endpointId: 'FanLight',
         cookie: {
-          capabilities: JSON.stringify([
+          capabilities: [
             {
               name: 'ToggleController',
               instance: 'Toggle:FanLight',
@@ -289,7 +289,7 @@ module.exports = [
               },
               item: { name: 'FanLight', type: 'String' }
             }
-          ])
+          ]
         }
       }
     },

--- a/lambda/test/alexa/chai.js
+++ b/lambda/test/alexa/chai.js
@@ -11,7 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+require('module-alias/register');
 const Ajv = require('ajv');
+const { decompressJSON } = require('@root/utils');
 
 // Initialize the alexa smart home message json schema draft v4 validator
 const validate = new Ajv({ schemaId: 'auto', unknownFormats: ['double', 'int32'] })
@@ -222,7 +224,7 @@ module.exports = function (chai) {
             new Assertion(getCapabilitiesSemantics(endpoint.capabilities)).deep.includes(value);
             break;
           case 'cookie':
-            new Assertion(JSON.parse(endpoint.cookie.capabilities)).include.deep.members(value);
+            new Assertion(decompressJSON(endpoint.cookie.capabilities)).include.deep.members(value);
             break;
           default:
             if (typeof endpoint[key] === 'object') {

--- a/lambda/test/alexa/smarthome.test.js
+++ b/lambda/test/alexa/smarthome.test.js
@@ -14,7 +14,7 @@
 require('module-alias/register');
 const { expect, use } = require('chai');
 const sinon = require('sinon');
-const { decamelize } = require('@root/utils');
+const { compressJSON, decamelize } = require('@root/utils');
 const log = require('@root/log');
 const OpenHAB = require('@openhab');
 const AlexaSmarthome = require('@alexa/smarthome');
@@ -120,9 +120,16 @@ function getDirective({ header, endpoint, payload = {} }) {
     // add endpoint only if provided
     ...(endpoint && {
       endpoint: {
+        scope: { type: 'BearerToken', token: 'access-token-from-skill' },
         endpointId: endpoint.endpointId,
-        cookie: endpoint.cookie,
-        scope: { type: 'BearerToken', token: 'access-token-from-skill' }
+        ...(endpoint.cookie && {
+          cookie: {
+            ...endpoint.cookie,
+            ...(typeof endpoint.cookie.capabilities === 'object' && {
+              capabilities: compressJSON(endpoint.cookie.capabilities)
+            })
+          }
+        })
       }
     }),
     payload: {

--- a/lambda/test/utils.test.js
+++ b/lambda/test/utils.test.js
@@ -13,7 +13,15 @@
 
 require('module-alias/register');
 const { expect } = require('chai');
-const { clamp, decamelize, isMACAddress, parseUrl, stripPunctuation } = require('@root/utils');
+const {
+  clamp,
+  compressJSON,
+  decompressJSON,
+  decamelize,
+  isMACAddress,
+  parseUrl,
+  stripPunctuation
+} = require('@root/utils');
 
 describe('Utilities Tests', () => {
   describe('clamp', () => {
@@ -27,6 +35,20 @@ describe('Utilities Tests', () => {
 
     it('above range', () => {
       expect(clamp(142, 0, 100)).to.equal(100);
+    });
+  });
+
+  describe('compress/decompress json', () => {
+    const object = { foo: 1, bar: 2 };
+
+    it('compressed json string', () => {
+      const string = compressJSON(object);
+      expect(decompressJSON(string)).to.deep.equal(object);
+    });
+
+    it('uncompressed json string', () => {
+      const string = JSON.stringify(object);
+      expect(decompressJSON(string)).to.deep.equal(object);
     });
   });
 

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -11,6 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+const { deflateSync, inflateSync } = require('zlib');
+
 /**
  * Defines utility functions
  * @type {Object}
@@ -25,6 +27,28 @@ module.exports = {
    */
   clamp: (value, minValue, maxValue) => {
     return Math.min(Math.max(value, minValue), maxValue);
+  },
+
+  /**
+   * Returns compressed json string
+   * @param  {Object} object
+   * @return {String}
+   */
+  compressJSON: (object) => {
+    return deflateSync(Buffer.from(JSON.stringify(object))).toString('base64');
+  },
+
+  /**
+   * Returns decompressed json object
+   * @param  {String} string
+   * @return {Object}
+   */
+  decompressJSON: (string) => {
+    try {
+      return JSON.parse(inflateSync(Buffer.from(string, 'base64')).toString());
+    } catch {
+      return JSON.parse(string);
+    }
   },
 
   /**


### PR DESCRIPTION
The [Alexa SMAPI](https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-discovery-objects.html#endpoint-object-definition) limits the endpoint cookie property included in the discovery response to 5000 bytes. When over that limit, the given endpoint is not discoverable.

This is an issue for `ModeController` or `RangeController` capabilities with more than 100 defined supported modes or presets configured especially if part of a group endpoint. Compressing the cookie property provides some additional wiggle room to include more options while adding a maximum hard cap to 150.