### PR TITLE
Convert to es module

### DIFF
--- a/lambda/.eslintrc.json
+++ b/lambda/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "eslint:recommended",
-    "plugin:node/recommended",
+    "plugin:n/recommended",
     "plugin:prettier/recommended"
   ],
   "parserOptions": {
@@ -9,6 +9,6 @@
   },
   "rules": {
     "no-console": "warn",
-    "node/no-missing-require": "off"
+    "n/no-missing-import": "off"
   }
 }

--- a/lambda/alexa/smarthome/capabilities/alexa.js
+++ b/lambda/alexa/smarthome/capabilities/alexa.js
@@ -11,15 +11,23 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Interface } = require('../constants');
+import AlexaCapability from './capability.js';
+import { Capability, Interface } from '../constants.js';
 
 /**
  * Defines Alexa interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-interface.html
  * @extends AlexaCapability
  */
-class Alexa extends AlexaCapability {
+export default class Alexa extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.ALEXA;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -28,5 +36,3 @@ class Alexa extends AlexaCapability {
     return Interface.ALEXA;
   }
 }
-
-module.exports = Alexa;

--- a/lambda/alexa/smarthome/capabilities/brightnessController.js
+++ b/lambda/alexa/smarthome/capabilities/brightnessController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Brightness } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Brightness } from '../properties/index.js';
 
 /**
  * Defines Alexa.BrightnessController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-brightnesscontroller.html
  * @extends AlexaCapability
  */
-class BrightnessController extends AlexaCapability {
+export default class BrightnessController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.BRIGHTNESS_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class BrightnessController extends AlexaCapability {
     return [AlexaDisplayCategory.LIGHT];
   }
 }
-
-module.exports = BrightnessController;

--- a/lambda/alexa/smarthome/capabilities/cameraStreamController.js
+++ b/lambda/alexa/smarthome/capabilities/cameraStreamController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { CameraStream } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { CameraStream } from '../properties/index.js';
 
 /**
  * Defines Alexa.CameraStreamController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-camerastreamcontroller.html
  * @extends AlexaCapability
  */
-class CameraStreamController extends AlexaCapability {
+export default class CameraStreamController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.CAMERA_STREAM_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -80,5 +88,3 @@ class CameraStreamController extends AlexaCapability {
     return capability;
   }
 }
-
-module.exports = CameraStreamController;

--- a/lambda/alexa/smarthome/capabilities/capability.js
+++ b/lambda/alexa/smarthome/capabilities/capability.js
@@ -11,12 +11,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { DecoupleState } = require('../properties');
+import { DecoupleState } from '../properties/index.js';
 
 /**
  * Defines alexa base capability class
  */
-class AlexaCapability {
+export default class AlexaCapability {
   /**
    * Constructor
    * @param {String} name
@@ -249,7 +249,7 @@ class AlexaCapability {
     const { name } = config;
     // Add property if is supported
     if (typeof this.supportedProperties[name] === 'function') {
-      const property = this.supportedProperties[name].build(config);
+      const property = this.supportedProperties[name].create(config);
       // Add property to list if defined and not already added
       if (property && !this.hasProperty(property)) {
         this._properties.push(property);
@@ -304,5 +304,3 @@ class AlexaCapability {
     }));
   }
 }
-
-module.exports = AlexaCapability;

--- a/lambda/alexa/smarthome/capabilities/channelController.js
+++ b/lambda/alexa/smarthome/capabilities/channelController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Channel, ChannelStep } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Channel, ChannelStep } from '../properties/index.js';
 
 /**
  * Defines Alexa.ChannelController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html
  * @extends AlexaCapability
  */
-class ChannelController extends AlexaCapability {
+export default class ChannelController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.CHANNEL_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -49,5 +57,3 @@ class ChannelController extends AlexaCapability {
     return [AlexaDisplayCategory.TV];
   }
 }
-
-module.exports = ChannelController;

--- a/lambda/alexa/smarthome/capabilities/colorController.js
+++ b/lambda/alexa/smarthome/capabilities/colorController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Color } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Color } from '../properties/index.js';
 
 /**
  * Defines Alexa.ColorController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-colorcontroller.html
  * @extends AlexaCapability
  */
-class ColorController extends AlexaCapability {
+export default class ColorController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.COLOR_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -72,5 +80,3 @@ class ColorController extends AlexaCapability {
     return super.getReportableProperties(items, properties);
   }
 }
-
-module.exports = ColorController;

--- a/lambda/alexa/smarthome/capabilities/colorTemperatureController.js
+++ b/lambda/alexa/smarthome/capabilities/colorTemperatureController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { ColorTemperature } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { ColorTemperature } from '../properties/index.js';
 
 /**
  * Defines Alexa.ColorTemperatureController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-colortemperaturecontroller.html
  * @extends AlexaCapability
  */
-class ColorTemperatureController extends AlexaCapability {
+export default class ColorTemperatureController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.COLOR_TEMPERATURE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -74,5 +82,3 @@ class ColorTemperatureController extends AlexaCapability {
     return super.getReportableProperties(items, properties);
   }
 }
-
-module.exports = ColorTemperatureController;

--- a/lambda/alexa/smarthome/capabilities/contactSensor.js
+++ b/lambda/alexa/smarthome/capabilities/contactSensor.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { DetectionState } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { DetectionState } from '../properties/index.js';
 
 /**
  * Defines Alexa.ContactSensor interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-contactsensor.html
  * @extends AlexaCapability
  */
-class ContactSensor extends AlexaCapability {
+export default class ContactSensor extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.CONTACT_SENSOR;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class ContactSensor extends AlexaCapability {
     return [AlexaDisplayCategory.CONTACT_SENSOR];
   }
 }
-
-module.exports = ContactSensor;

--- a/lambda/alexa/smarthome/capabilities/endpointHealth.js
+++ b/lambda/alexa/smarthome/capabilities/endpointHealth.js
@@ -11,16 +11,24 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Interface, Property } = require('../constants');
-const { Connectivity } = require('../properties');
+import AlexaCapability from './capability.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Connectivity } from '../properties/index.js';
 
 /**
  * Defines Alexa.EndpointHealth interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-endpointhealth.html
  * @extends AlexaCapability
  */
-class EndpointHealth extends AlexaCapability {
+export default class EndpointHealth extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.ENDPOINT_HEALTH;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -39,5 +47,3 @@ class EndpointHealth extends AlexaCapability {
     };
   }
 }
-
-module.exports = EndpointHealth;

--- a/lambda/alexa/smarthome/capabilities/equalizerController.js
+++ b/lambda/alexa/smarthome/capabilities/equalizerController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { EqualizerBands, EqualizerMode } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { EqualizerBands, EqualizerMode } from '../properties/index.js';
 
 /**
  * Defines Alexa.EqualizerController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-equalizercontroller.html
  * @extends AlexaCapability
  */
-class EqualizerController extends AlexaCapability {
+export default class EqualizerController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.EQUALIZER_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -76,5 +84,3 @@ class EqualizerController extends AlexaCapability {
     return capability;
   }
 }
-
-module.exports = EqualizerController;

--- a/lambda/alexa/smarthome/capabilities/genericController.js
+++ b/lambda/alexa/smarthome/capabilities/genericController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { AlexaCapabilityResources } = require('../resources');
-const Generic = require('../properties/generic');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Generic } from '../properties/index.js';
+import { AlexaCapabilityResources } from '../resources.js';
 
 /**
  * Defines alexa generic controller capability class
  *  https://developer.amazon.com/docs/device-apis/generic-controllers.html
  * @extends AlexaCapability
  */
-class GenericController extends AlexaCapability {
+export default class GenericController extends AlexaCapability {
   /**
    * Constructor
    * @param {String} name
@@ -71,5 +71,3 @@ class GenericController extends AlexaCapability {
     return AlexaCapabilityResources.getResources(labels, language);
   }
 }
-
-module.exports = GenericController;

--- a/lambda/alexa/smarthome/capabilities/index.js
+++ b/lambda/alexa/smarthome/capabilities/index.js
@@ -11,52 +11,35 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability } = require('../constants');
-
 /**
- * Defines supported capability classes
- * @type {Object}
+ * Exports supported capability classes
  */
-module.exports = {
-  [Capability.ALEXA]: require('./alexa'),
-  [Capability.BRIGHTNESS_CONTROLLER]: require('./brightnessController'),
-  [Capability.CAMERA_STREAM_CONTROLLER]: require('./cameraStreamController'),
-  [Capability.CHANNEL_CONTROLLER]: require('./channelController'),
-  [Capability.COLOR_CONTROLLER]: require('./colorController'),
-  [Capability.COLOR_TEMPERATURE_CONTROLLER]: require('./colorTemperatureController'),
-  [Capability.CONTACT_SENSOR]: require('./contactSensor'),
-  [Capability.ENDPOINT_HEALTH]: require('./endpointHealth'),
-  [Capability.EQUALIZER_CONTROLLER]: require('./equalizerController'),
-  [Capability.INPUT_CONTROLLER]: require('./inputController'),
-  [Capability.LOCK_CONTROLLER]: require('./lockController'),
-  [Capability.MODE_CONTROLLER]: require('./modeController'),
-  [Capability.MOTION_SENSOR]: require('./motionSensor'),
-  [Capability.NETWORKING_ACCESS_CONTROLLER]: require('./networkingAccessController'),
-  [Capability.NETWORKING_CONNECTED_DEVICE]: require('./networkingConnectedDevice'),
-  [Capability.NETWORKING_HOME_NETWORK_CONTROLLER]: require('./networkingHomeNetworkController'),
-  [Capability.PERCENTAGE_CONTROLLER]: require('./percentageController'),
-  [Capability.PLAYBACK_CONTROLLER]: require('./playbackController'),
-  [Capability.POWER_CONTROLLER]: require('./powerController'),
-  [Capability.POWER_LEVEL_CONTROLLER]: require('./powerLevelController'),
-  [Capability.RANGE_CONTROLLER]: require('./rangeController'),
-  [Capability.SAFETY]: require('./safety'),
-  [Capability.SCENE_CONTROLLER]: require('./sceneController'),
-  [Capability.SECURITY_PANEL_CONTROLLER]: require('./securityPanelController'),
-  [Capability.SPEAKER]: require('./speaker'),
-  [Capability.STEP_SPEAKER]: require('./stepSpeaker'),
-  [Capability.TEMPERATURE_SENSOR]: require('./temperatureSensor'),
-  [Capability.THERMOSTAT_CONTROLLER]: require('./thermostatController'),
-  [Capability.TOGGLE_CONTROLLER]: require('./toggleController')
-};
-
-/**
- * Returns new capability object for a given name and instance
- * @param  {String} name
- * @param  {String} instance
- * @return {Object}
- */
-module.exports.build = function (name, instance) {
-  if (typeof this[name] === 'function') {
-    return new this[name](name, instance);
-  }
-};
+export { default as Alexa } from './alexa.js';
+export { default as BrightnessController } from './brightnessController.js';
+export { default as CameraStreamController } from './cameraStreamController.js';
+export { default as ChannelController } from './channelController.js';
+export { default as ColorController } from './colorController.js';
+export { default as ColorTemperatureController } from './colorTemperatureController.js';
+export { default as ContactSensor } from './contactSensor.js';
+export { default as EndpointHealth } from './endpointHealth.js';
+export { default as EqualizerController } from './equalizerController.js';
+export { default as InputController } from './inputController.js';
+export { default as LockController } from './lockController.js';
+export { default as ModeController } from './modeController.js';
+export { default as MotionSensor } from './motionSensor.js';
+export { default as NetworkingAccessController } from './networkingAccessController.js';
+export { default as NetworkingConnectedDevice } from './networkingConnectedDevice.js';
+export { default as NetworkingHomeNetworkController } from './networkingHomeNetworkController.js';
+export { default as PercentageController } from './percentageController.js';
+export { default as PlaybackController } from './playbackController.js';
+export { default as PowerController } from './powerController.js';
+export { default as PowerLevelController } from './powerLevelController.js';
+export { default as RangeController } from './rangeController.js';
+export { default as Safety } from './safety.js';
+export { default as SceneController } from './sceneController.js';
+export { default as SecurityPanelController } from './securityPanelController.js';
+export { default as Speaker } from './speaker.js';
+export { default as StepSpeaker } from './stepSpeaker.js';
+export { default as TemperatureSensor } from './temperatureSensor.js';
+export { default as ThermostatController } from './thermostatController.js';
+export { default as ToggleController } from './toggleController.js';

--- a/lambda/alexa/smarthome/capabilities/inputController.js
+++ b/lambda/alexa/smarthome/capabilities/inputController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Input } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Input } from '../properties/index.js';
 
 /**
  * Defines Alexa.InputController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-inputcontroller.html
  * @extends AlexaCapability
  */
-class InputController extends AlexaCapability {
+export default class InputController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.INPUT_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -62,5 +70,3 @@ class InputController extends AlexaCapability {
     return capability;
   }
 }
-
-module.exports = InputController;

--- a/lambda/alexa/smarthome/capabilities/lockController.js
+++ b/lambda/alexa/smarthome/capabilities/lockController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { LockState } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { LockState } from '../properties/index.js';
 
 /**
  * Defines Alexa.LockController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html
  * @extends AlexaCapability
  */
-class LockController extends AlexaCapability {
+export default class LockController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.LOCK_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class LockController extends AlexaCapability {
     return [AlexaDisplayCategory.SMARTLOCK];
   }
 }
-
-module.exports = LockController;

--- a/lambda/alexa/smarthome/capabilities/modeController.js
+++ b/lambda/alexa/smarthome/capabilities/modeController.js
@@ -11,19 +11,27 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const ModeControllerHandler = require('../handlers/modeController');
-const { Mode } = require('../properties');
-const { AlexaModeResources } = require('../resources');
-const AlexaSemantics = require('../semantics');
-const GenericController = require('./genericController');
+import { Capability, Interface, Property } from '../constants.js';
+import ModeControllerHandler from '../handlers/modeController.js';
+import { Mode } from '../properties/index.js';
+import { AlexaModeResources } from '../resources.js';
+import AlexaSemantics from '../semantics.js';
+import GenericController from './genericController.js';
 
 /**
  * Defines Alexa.ModeController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-modecontroller.html
  * @extends GenericController
  */
-class ModeController extends GenericController {
+export default class ModeController extends GenericController {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.MODE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -103,5 +111,3 @@ class ModeController extends GenericController {
     return semantics.toJSON();
   }
 }
-
-module.exports = ModeController;

--- a/lambda/alexa/smarthome/capabilities/motionSensor.js
+++ b/lambda/alexa/smarthome/capabilities/motionSensor.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { DetectionState } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { DetectionState } from '../properties/index.js';
 
 /**
  * Defines Alexa.MotionSensor interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-motionsensor.html
  * @extends AlexaCapability
  */
-class MotionSensor extends AlexaCapability {
+export default class MotionSensor extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.MOTION_SENSOR;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class MotionSensor extends AlexaCapability {
     return [AlexaDisplayCategory.MOTION_SENSOR];
   }
 }
-
-module.exports = MotionSensor;

--- a/lambda/alexa/smarthome/capabilities/networkingAccessController.js
+++ b/lambda/alexa/smarthome/capabilities/networkingAccessController.js
@@ -11,16 +11,24 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Capability, Interface, Property } = require('../constants');
-const { NetworkAccess } = require('../properties');
+import AlexaCapability from './capability.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { NetworkAccess } from '../properties/index.js';
 
 /**
  * Defines Alexa.Networking.AccessController interface capability class
  *  https://developer.amazon.com/docs/networking/alexa-networking-accesscontroller.html
  * @extends AlexaCapability
  */
-class NetworkingAccessController extends AlexaCapability {
+export default class NetworkingAccessController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.NETWORKING_ACCESS_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -55,5 +63,3 @@ class NetworkingAccessController extends AlexaCapability {
     return { supportsScheduling: false };
   }
 }
-
-module.exports = NetworkingAccessController;

--- a/lambda/alexa/smarthome/capabilities/networkingConnectedDevice.js
+++ b/lambda/alexa/smarthome/capabilities/networkingConnectedDevice.js
@@ -11,16 +11,24 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Interface, Property } = require('../constants');
-const { ConnectedDevice } = require('../properties');
+import AlexaCapability from './capability.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { ConnectedDevice } from '../properties/index.js';
 
 /**
  * Defines Alexa.Networking.ConnectedDevice interface capability class
  *  https://developer.amazon.com/docs/networking/alexa-networking-connecteddevice.html
  * @extends AlexaCapability
  */
-class NetworkingConnectedDevice extends AlexaCapability {
+export default class NetworkingConnectedDevice extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.NETWORKING_CONNECTED_DEVICE;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -65,5 +73,3 @@ class NetworkingConnectedDevice extends AlexaCapability {
     return relationship;
   }
 }
-
-module.exports = NetworkingConnectedDevice;

--- a/lambda/alexa/smarthome/capabilities/networkingHomeNetworkController.js
+++ b/lambda/alexa/smarthome/capabilities/networkingHomeNetworkController.js
@@ -11,15 +11,23 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Interface } = require('../constants');
+import AlexaCapability from './capability.js';
+import { Capability, Interface } from '../constants.js';
 
 /**
  * Defines Alexa.Networking.HomeNetworkController interface capability class
  *  https://developer.amazon.com/docs/networking/alexa-networking-homenetworkcontroller.html
  * @extends AlexaCapability
  */
-class NetworkingHomeNetworkController extends AlexaCapability {
+export default class NetworkingHomeNetworkController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.NETWORKING_HOME_NETWORK_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -28,5 +36,3 @@ class NetworkingHomeNetworkController extends AlexaCapability {
     return Interface.ALEXA_NETWORKING_HOME_NETWORK_CONTROLLER;
   }
 }
-
-module.exports = NetworkingHomeNetworkController;

--- a/lambda/alexa/smarthome/capabilities/percentageController.js
+++ b/lambda/alexa/smarthome/capabilities/percentageController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Percentage } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Percentage } from '../properties/index.js';
 
 /**
  * Defines Alexa.PercentageController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-percentagecontroller.html
  * @extends AlexaCapability
  */
-class PercentageController extends AlexaCapability {
+export default class PercentageController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.PERCENTAGE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class PercentageController extends AlexaCapability {
     return [AlexaDisplayCategory.OTHER];
   }
 }
-
-module.exports = PercentageController;

--- a/lambda/alexa/smarthome/capabilities/playbackController.js
+++ b/lambda/alexa/smarthome/capabilities/playbackController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Playback, PlaybackStop, PlaybackAction } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Playback, PlaybackStop, PlaybackAction } from '../properties/index.js';
 
 /**
  * Defines Alexa.PlaybackController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-playbackcontroller.html
  * @extends AlexaCapability
  */
-class PlaybackController extends AlexaCapability {
+export default class PlaybackController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.PLAYBACK_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -75,5 +83,3 @@ class PlaybackController extends AlexaCapability {
     return capability;
   }
 }
-
-module.exports = PlaybackController;

--- a/lambda/alexa/smarthome/capabilities/powerController.js
+++ b/lambda/alexa/smarthome/capabilities/powerController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { PowerState } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { PowerState } from '../properties/index.js';
 
 /**
  * Defines Alexa.PowerController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-powercontroller.html
  * @extends AlexaCapability
  */
-class PowerController extends AlexaCapability {
+export default class PowerController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.POWER_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class PowerController extends AlexaCapability {
     return [AlexaDisplayCategory.SWITCH];
   }
 }
-
-module.exports = PowerController;

--- a/lambda/alexa/smarthome/capabilities/powerLevelController.js
+++ b/lambda/alexa/smarthome/capabilities/powerLevelController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { PowerLevel } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { PowerLevel } from '../properties/index.js';
 
 /**
  * Defines Alexa.PowerLevelController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html
  * @extends AlexaCapability
  */
-class PowerLevelController extends AlexaCapability {
+export default class PowerLevelController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.POWER_LEVEL_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class PowerLevelController extends AlexaCapability {
     return [AlexaDisplayCategory.SWITCH];
   }
 }
-
-module.exports = PowerLevelController;

--- a/lambda/alexa/smarthome/capabilities/rangeController.js
+++ b/lambda/alexa/smarthome/capabilities/rangeController.js
@@ -11,19 +11,27 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const RangeControllerHandler = require('../handlers/rangeController');
-const { RangeValue } = require('../properties');
-const { AlexaPresetResources } = require('../resources');
-const AlexaSemantics = require('../semantics');
-const GenericController = require('./genericController');
+import { Capability, Interface, Property } from '../constants.js';
+import RangeControllerHandler from '../handlers/rangeController.js';
+import { RangeValue } from '../properties/index.js';
+import { AlexaPresetResources } from '../resources.js';
+import AlexaSemantics from '../semantics.js';
+import GenericController from './genericController.js';
 
 /**
  * Defines Alexa.RangeController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html
  * @extends GenericController
  */
-class RangeController extends GenericController {
+export default class RangeController extends GenericController {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.RANGE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -119,5 +127,3 @@ class RangeController extends GenericController {
     return semantics.toJSON();
   }
 }
-
-module.exports = RangeController;

--- a/lambda/alexa/smarthome/capabilities/safety.js
+++ b/lambda/alexa/smarthome/capabilities/safety.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const { Capability, Interface, Property } = require('../constants');
-const { OpenState } = require('../device/attributes');
-const { AlertState } = require('../properties');
+import AlexaCapability from './capability.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { OpenState } from '../device/attributes/index.js';
+import { AlertState } from '../properties/index.js';
 
 /**
  * Defines Alexa.Safety interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-safety-errorresponse.html
  * @extends AlexaCapability
  */
-class Safety extends AlexaCapability {
+export default class Safety extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.SAFETY;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -57,5 +65,3 @@ class Safety extends AlexaCapability {
     return false;
   }
 }
-
-module.exports = Safety;

--- a/lambda/alexa/smarthome/capabilities/sceneController.js
+++ b/lambda/alexa/smarthome/capabilities/sceneController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Scene } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Scene } from '../properties/index.js';
 
 /**
  * Defines Alexa.SceneController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-scenecontroller.html
  * @extends AlexaCapability
  */
-class SceneController extends AlexaCapability {
+export default class SceneController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.SCENE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -62,5 +70,3 @@ class SceneController extends AlexaCapability {
     return capability;
   }
 }
-
-module.exports = SceneController;

--- a/lambda/alexa/smarthome/capabilities/securityPanelController.js
+++ b/lambda/alexa/smarthome/capabilities/securityPanelController.js
@@ -11,17 +11,26 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { ArmState, AlarmState, SecurityAlert } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { ArmState, AlarmState, SecurityAlert } from '../properties/index.js';
+import { AuthType } from '../properties/armState.js';
 
 /**
  * Defines Alexa.SecurityPanelController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html
  * @extends AlexaCapability
  */
-class SecurityPanelController extends AlexaCapability {
+export default class SecurityPanelController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.SECURITY_PANEL_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -70,12 +79,10 @@ class SecurityPanelController extends AlexaCapability {
       configuration.supportedArmStates = supportedArmStates.map((state) => ({ value: state }));
 
       if (pinCodes.length > 0) {
-        configuration.supportedAuthorizationTypes = [{ type: ArmState.AuthType.FOUR_DIGIT_PIN }];
+        configuration.supportedAuthorizationTypes = [{ type: AuthType.FOUR_DIGIT_PIN }];
       }
     }
 
     return configuration;
   }
 }
-
-module.exports = SecurityPanelController;

--- a/lambda/alexa/smarthome/capabilities/speaker.js
+++ b/lambda/alexa/smarthome/capabilities/speaker.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { MuteState, VolumeLevel } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { MuteState, VolumeLevel } from '../properties/index.js';
 
 /**
  * Defines Alexa.Speaker interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-speaker.html
  * @extends AlexaCapability
  */
-class Speaker extends AlexaCapability {
+export default class Speaker extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.SPEAKER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -49,5 +57,3 @@ class Speaker extends AlexaCapability {
     return [AlexaDisplayCategory.SPEAKER];
   }
 }
-
-module.exports = Speaker;

--- a/lambda/alexa/smarthome/capabilities/stepSpeaker.js
+++ b/lambda/alexa/smarthome/capabilities/stepSpeaker.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { MuteStep, VolumeStep } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { MuteStep, VolumeStep } from '../properties/index.js';
 
 /**
  * Defines Alexa.StepSpeaker interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html
  * @extends AlexaCapability
  */
-class StepSpeaker extends AlexaCapability {
+export default class StepSpeaker extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.STEP_SPEAKER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -49,5 +57,3 @@ class StepSpeaker extends AlexaCapability {
     return [AlexaDisplayCategory.SPEAKER];
   }
 }
-
-module.exports = StepSpeaker;

--- a/lambda/alexa/smarthome/capabilities/temperatureSensor.js
+++ b/lambda/alexa/smarthome/capabilities/temperatureSensor.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { Temperature } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { Temperature } from '../properties/index.js';
 
 /**
  * Defines Alexa.TemperatureSensor interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-temperaturesensor.html
  * @extends AlexaCapability
  */
-class TemperatureSensor extends AlexaCapability {
+export default class TemperatureSensor extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.TEMPERATURE_SENSOR;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -48,5 +56,3 @@ class TemperatureSensor extends AlexaCapability {
     return [AlexaDisplayCategory.TEMPERATURE_SENSOR];
   }
 }
-
-module.exports = TemperatureSensor;

--- a/lambda/alexa/smarthome/capabilities/thermostatController.js
+++ b/lambda/alexa/smarthome/capabilities/thermostatController.js
@@ -11,17 +11,25 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaCapability = require('./capability');
-const AlexaDisplayCategory = require('../category');
-const { Interface, Property } = require('../constants');
-const { TargetSetpoint, UpperSetpoint, LowerSetpoint, ThermostatMode, ThermostatHold } = require('../properties');
+import AlexaCapability from './capability.js';
+import AlexaDisplayCategory from '../category.js';
+import { Capability, Interface, Property } from '../constants.js';
+import { TargetSetpoint, UpperSetpoint, LowerSetpoint, ThermostatMode, ThermostatHold } from '../properties/index.js';
 
 /**
  * Defines Alexa.ThermostatController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-thermostatcontroller.html
  * @extends AlexaCapability
  */
-class ThermostatController extends AlexaCapability {
+export default class ThermostatController extends AlexaCapability {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.THERMOSTAT_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -141,5 +149,3 @@ class ThermostatController extends AlexaCapability {
     };
   }
 }
-
-module.exports = ThermostatController;

--- a/lambda/alexa/smarthome/capabilities/toggleController.js
+++ b/lambda/alexa/smarthome/capabilities/toggleController.js
@@ -11,19 +11,27 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemValue } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const ToggleControllerHandler = require('../handlers/toggleController');
-const { ToggleState } = require('../properties');
-const AlexaSemantics = require('../semantics');
-const GenericController = require('./genericController');
+import { ItemValue } from '#openhab/constants.js';
+import { Capability, Interface, Property } from '../constants.js';
+import ToggleControllerHandler from '../handlers/toggleController.js';
+import { ToggleState } from '../properties/index.js';
+import AlexaSemantics from '../semantics.js';
+import GenericController from './genericController.js';
 
 /**
  * Defines Alexa.ToggleController interface capability class
  *  https://developer.amazon.com/docs/device-apis/alexa-togglecontroller.html
  * @extends GenericController
  */
-class ToggleController extends GenericController {
+export default class ToggleController extends GenericController {
+  /**
+   * Returns name
+   * @return {String}
+   */
+  static get name() {
+    return Capability.TOGGLE_CONTROLLER;
+  }
+
   /**
    * Returns interface
    * @return {String}
@@ -72,5 +80,3 @@ class ToggleController extends GenericController {
     return semantics.toJSON();
   }
 }
-
-module.exports = ToggleController;

--- a/lambda/alexa/smarthome/catalog.js
+++ b/lambda/alexa/smarthome/catalog.js
@@ -11,6 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
 /**
  * Defines alexa global catalog class
  *    https://developer.amazon.com/docs/device-apis/resources-and-assets.html#global-alexa-catalog
@@ -255,7 +259,7 @@ class AlexaGlobalCatalog {
  * Defines alexa asset catalog class
  * @extends AlexaGlobalCatalog
  */
-class AlexaAssetCatalog extends AlexaGlobalCatalog {
+export default class AlexaAssetCatalog extends AlexaGlobalCatalog {
   /**
    * Defines setting angle asset
    * @type {String}
@@ -447,7 +451,7 @@ class AlexaAssetCatalog extends AlexaGlobalCatalog {
    * @return {Object}
    */
   static get labelValues() {
-    return require('@root/catalog.json');
+    return require('#root/catalog.json');
   }
 
   /**
@@ -468,5 +472,3 @@ class AlexaAssetCatalog extends AlexaGlobalCatalog {
     return super.isSupported(assetId) ? super.getLabels(assetId) : this.labelValues[assetId];
   }
 }
-
-module.exports = AlexaAssetCatalog;

--- a/lambda/alexa/smarthome/category.js
+++ b/lambda/alexa/smarthome/category.js
@@ -15,7 +15,7 @@
  * Defines alexa display category class
  *  https://developer.amazon.com/docs/device-apis/alexa-discovery.html#display-categories
  */
-class AlexaDisplayCategory {
+export default class AlexaDisplayCategory {
   /**
    * Defines activity trigger display category
    * @type {String}
@@ -343,5 +343,3 @@ class AlexaDisplayCategory {
     return Object.values(this).includes(category);
   }
 }
-
-module.exports = AlexaDisplayCategory;

--- a/lambda/alexa/smarthome/constants.js
+++ b/lambda/alexa/smarthome/constants.js
@@ -15,7 +15,7 @@
  * Defines alexa capability enum
  * @type {Object}
  */
-const Capability = Object.freeze({
+export const Capability = Object.freeze({
   ALEXA: 'Alexa',
   BRIGHTNESS_CONTROLLER: 'BrightnessController',
   CAMERA_STREAM_CONTROLLER: 'CameraStreamController',
@@ -51,7 +51,7 @@ const Capability = Object.freeze({
  * Defines alexa interface enum
  * @type {Object}
  */
-const Interface = Object.freeze({
+export const Interface = Object.freeze({
   ALEXA: 'Alexa',
   ALEXA_AUTHORIZATION: 'Alexa.Authorization',
   ALEXA_BRIGHTNESS_CONTROLLER: 'Alexa.BrightnessController',
@@ -89,7 +89,7 @@ const Interface = Object.freeze({
  * Defines alexa property enum
  * @type {Object}
  */
-const Property = Object.freeze({
+export const Property = Object.freeze({
   ALARM_ALERT: 'alarmAlert',
   ARM_STATE: 'armState',
   BRIGHTNESS: 'brightness',
@@ -133,9 +133,3 @@ const Property = Object.freeze({
   WATER_ALARM: 'waterAlarm',
   ZONES_ALERT: 'zonesAlert'
 });
-
-module.exports = {
-  Capability,
-  Interface,
-  Property
-};

--- a/lambda/alexa/smarthome/device/attributes/alarmAlert.js
+++ b/lambda/alexa/smarthome/device/attributes/alarmAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines alarm alert attribute class
  * @extends DeviceAttribute
  */
-class AlarmAlert extends DeviceAttribute {
+export default class AlarmAlert extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class AlarmAlert extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.ALARM_ALERT }];
   }
 }
-
-module.exports = AlarmAlert;

--- a/lambda/alexa/smarthome/device/attributes/armState.js
+++ b/lambda/alexa/smarthome/device/attributes/armState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines arm state attribute class
  * @extends DeviceAttribute
  */
-class ArmState extends DeviceAttribute {
+export default class ArmState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -38,5 +38,3 @@ class ArmState extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.ARM_STATE }];
   }
 }
-
-module.exports = ArmState;

--- a/lambda/alexa/smarthome/device/attributes/attribute.js
+++ b/lambda/alexa/smarthome/device/attributes/attribute.js
@@ -14,7 +14,7 @@
 /**
  * Defines device attribute base class
  */
-class DeviceAttribute {
+export default class DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -31,5 +31,3 @@ class DeviceAttribute {
     return [];
   }
 }
-
-module.exports = DeviceAttribute;

--- a/lambda/alexa/smarthome/device/attributes/batteryLevel.js
+++ b/lambda/alexa/smarthome/device/attributes/batteryLevel.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines battery level attribute class
  * @extends DeviceAttribute
  */
-class BatteryLevel extends DeviceAttribute {
+export default class BatteryLevel extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -66,5 +66,3 @@ class BatteryLevel extends DeviceAttribute {
     }
   }
 }
-
-module.exports = BatteryLevel;

--- a/lambda/alexa/smarthome/device/attributes/brightness.js
+++ b/lambda/alexa/smarthome/device/attributes/brightness.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines brightness attribute class
  * @extends DeviceAttribute
  */
-class Brightness extends DeviceAttribute {
+export default class Brightness extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Brightness extends DeviceAttribute {
     return [{ name: Capability.BRIGHTNESS_CONTROLLER, property: Property.BRIGHTNESS }];
   }
 }
-
-module.exports = Brightness;

--- a/lambda/alexa/smarthome/device/attributes/burglaryAlarm.js
+++ b/lambda/alexa/smarthome/device/attributes/burglaryAlarm.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines burglary alarm attribute class
  * @extends DeviceAttribute
  */
-class BurglaryAlarm extends DeviceAttribute {
+export default class BurglaryAlarm extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class BurglaryAlarm extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.BURGLARY_ALARM }];
   }
 }
-
-module.exports = BurglaryAlarm;

--- a/lambda/alexa/smarthome/device/attributes/cameraStream.js
+++ b/lambda/alexa/smarthome/device/attributes/cameraStream.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines camera stream attribute class
  * @extends DeviceAttribute
  */
-class CameraStream extends DeviceAttribute {
+export default class CameraStream extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class CameraStream extends DeviceAttribute {
     return [{ name: Capability.CAMERA_STREAM_CONTROLLER, property: Property.CAMERA_STREAM }];
   }
 }
-
-module.exports = CameraStream;

--- a/lambda/alexa/smarthome/device/attributes/carbonMonoxideAlarm.js
+++ b/lambda/alexa/smarthome/device/attributes/carbonMonoxideAlarm.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines carbon monoxide alarm attribute class
  * @extends DeviceAttribute
  */
-class CarbonMonoxideAlarm extends DeviceAttribute {
+export default class CarbonMonoxideAlarm extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class CarbonMonoxideAlarm extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.CARBON_MONOXIDE_ALARM }];
   }
 }
-
-module.exports = CarbonMonoxideAlarm;

--- a/lambda/alexa/smarthome/device/attributes/channel.js
+++ b/lambda/alexa/smarthome/device/attributes/channel.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines channel attribute class
  * @extends DeviceAttribute
  */
-class Channel extends DeviceAttribute {
+export default class Channel extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -38,5 +38,3 @@ class Channel extends DeviceAttribute {
     return [{ name: Capability.CHANNEL_CONTROLLER, property: Property.CHANNEL }];
   }
 }
-
-module.exports = Channel;

--- a/lambda/alexa/smarthome/device/attributes/channelStep.js
+++ b/lambda/alexa/smarthome/device/attributes/channelStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines channel step attribute class
  * @extends DeviceAttribute
  */
-class ChannelStep extends DeviceAttribute {
+export default class ChannelStep extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ChannelStep extends DeviceAttribute {
     return [{ name: Capability.CHANNEL_CONTROLLER, property: Property.CHANNEL_STEP }];
   }
 }
-
-module.exports = ChannelStep;

--- a/lambda/alexa/smarthome/device/attributes/color.js
+++ b/lambda/alexa/smarthome/device/attributes/color.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines color attribute class
  * @extends DeviceAttribute
  */
-class Color extends DeviceAttribute {
+export default class Color extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Color extends DeviceAttribute {
     return [{ name: Capability.COLOR_CONTROLLER, property: Property.COLOR }];
   }
 }
-
-module.exports = Color;

--- a/lambda/alexa/smarthome/device/attributes/colorTemperature.js
+++ b/lambda/alexa/smarthome/device/attributes/colorTemperature.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines color temperature attribute class
  * @extends DeviceAttribute
  */
-class ColorTemperature extends DeviceAttribute {
+export default class ColorTemperature extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ColorTemperature extends DeviceAttribute {
     return [{ name: Capability.COLOR_TEMPERATURE_CONTROLLER, property: Property.COLOR_TEMPERATURE }];
   }
 }
-
-module.exports = ColorTemperature;

--- a/lambda/alexa/smarthome/device/attributes/contactDetectionState.js
+++ b/lambda/alexa/smarthome/device/attributes/contactDetectionState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines contact detection state attribute class
  * @extends DeviceAttribute
  */
-class ContactDetectionState extends DeviceAttribute {
+export default class ContactDetectionState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ContactDetectionState extends DeviceAttribute {
     return [{ name: Capability.CONTACT_SENSOR, property: Property.DETECTION_STATE }];
   }
 }
-
-module.exports = ContactDetectionState;

--- a/lambda/alexa/smarthome/device/attributes/coolingSetpoint.js
+++ b/lambda/alexa/smarthome/device/attributes/coolingSetpoint.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const Temperature = require('./temperature');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import Temperature from './temperature.js';
 
 /**
  * Defines cooling setpoint attribute class
  * @extends Temperature
  */
-class CoolingSetpoint extends Temperature {
+export default class CoolingSetpoint extends Temperature {
   /**
    * Returns supported names
    * @return {Array}
@@ -49,5 +49,3 @@ class CoolingSetpoint extends Temperature {
     ];
   }
 }
-
-module.exports = CoolingSetpoint;

--- a/lambda/alexa/smarthome/device/attributes/currentLockState.js
+++ b/lambda/alexa/smarthome/device/attributes/currentLockState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const DecoupleState = require('@alexa/smarthome/properties/decoupleState');
-const LockState = require('./lockState');
+import { DecoupleState } from '#alexa/smarthome/properties/index.js';
+import LockState from './lockState.js';
 
 /**
  * Defines current lock state attribute class
  * @extends LockState
  */
-class CurrentLockState extends LockState {
+export default class CurrentLockState extends LockState {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class CurrentLockState extends LockState {
     return DecoupleState.TAG_NAME;
   }
 }
-
-module.exports = CurrentLockState;

--- a/lambda/alexa/smarthome/device/attributes/currentOpenState.js
+++ b/lambda/alexa/smarthome/device/attributes/currentOpenState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const DecoupleState = require('@alexa/smarthome/properties/decoupleState');
-const OpenState = require('./openState');
+import { DecoupleState } from '#alexa/smarthome/properties/index.js';
+import OpenState from './openState.js';
 
 /**
  * Defines current open state attribute class
  * @extends OpenState
  */
-class CurrentOpenState extends OpenState {
+export default class CurrentOpenState extends OpenState {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class CurrentOpenState extends OpenState {
     return DecoupleState.TAG_NAME;
   }
 }
-
-module.exports = CurrentOpenState;

--- a/lambda/alexa/smarthome/device/attributes/ecoCoolingSetpoint.js
+++ b/lambda/alexa/smarthome/device/attributes/ecoCoolingSetpoint.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const ThermostatMode = require('@alexa/smarthome/properties/thermostatMode');
-const CoolingSetpoint = require('./coolingSetpoint');
+import { ThermostatMode } from '#alexa/smarthome/properties/index.js';
+import CoolingSetpoint from './coolingSetpoint.js';
 
 /**
  * Defines eco cooling setpoint attribute class
  * @extends CoolingSetpoint
  */
-class EcoCoolingSetpoint extends CoolingSetpoint {
+export default class EcoCoolingSetpoint extends CoolingSetpoint {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class EcoCoolingSetpoint extends CoolingSetpoint {
     return ThermostatMode.ECO.toLowerCase();
   }
 }
-
-module.exports = EcoCoolingSetpoint;

--- a/lambda/alexa/smarthome/device/attributes/ecoHeatingSetpoint.js
+++ b/lambda/alexa/smarthome/device/attributes/ecoHeatingSetpoint.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const ThermostatMode = require('@alexa/smarthome/properties/thermostatMode');
-const HeatingSetpoint = require('./heatingSetpoint');
+import { ThermostatMode } from '#alexa/smarthome/properties/index.js';
+import HeatingSetpoint from './heatingSetpoint.js';
 
 /**
  * Defines eco heating setpoint attribute class
  * @extends HeatingSetpoint
  */
-class EcoHeatingSetpoint extends HeatingSetpoint {
+export default class EcoHeatingSetpoint extends HeatingSetpoint {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class EcoHeatingSetpoint extends HeatingSetpoint {
     return ThermostatMode.ECO.toLowerCase();
   }
 }
-
-module.exports = EcoHeatingSetpoint;

--- a/lambda/alexa/smarthome/device/attributes/equalizerBass.js
+++ b/lambda/alexa/smarthome/device/attributes/equalizerBass.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const EqualizerBands = require('@alexa/smarthome/properties/equalizerBands');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { EqualizerBands } from '#alexa/smarthome/properties/index.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines equalizer band bass attribute class
  * @extends DeviceAttribute
  */
-class EqualizerBass extends DeviceAttribute {
+export default class EqualizerBass extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -42,5 +42,3 @@ class EqualizerBass extends DeviceAttribute {
     ];
   }
 }
-
-module.exports = EqualizerBass;

--- a/lambda/alexa/smarthome/device/attributes/equalizerMidrange.js
+++ b/lambda/alexa/smarthome/device/attributes/equalizerMidrange.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const EqualizerBands = require('@alexa/smarthome/properties/equalizerBands');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { EqualizerBands } from '#alexa/smarthome/properties/index.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines equalizer band midrange attribute class
  * @extends DeviceAttribute
  */
-class EqualizerMidrange extends DeviceAttribute {
+export default class EqualizerMidrange extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -42,5 +42,3 @@ class EqualizerMidrange extends DeviceAttribute {
     ];
   }
 }
-
-module.exports = EqualizerMidrange;

--- a/lambda/alexa/smarthome/device/attributes/equalizerMode.js
+++ b/lambda/alexa/smarthome/device/attributes/equalizerMode.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines equalizer mode attribute class
  * @extends DeviceAttribute
  */
-class EqualizerMode extends DeviceAttribute {
+export default class EqualizerMode extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class EqualizerMode extends DeviceAttribute {
     return [{ name: Capability.EQUALIZER_CONTROLLER, property: Property.EQUALIZER_MODE }];
   }
 }
-
-module.exports = EqualizerMode;

--- a/lambda/alexa/smarthome/device/attributes/equalizerTreble.js
+++ b/lambda/alexa/smarthome/device/attributes/equalizerTreble.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const EqualizerBands = require('@alexa/smarthome/properties/equalizerBands');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { EqualizerBands } from '#alexa/smarthome/properties/index.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines equalizer band treble attribute class
  * @extends DeviceAttribute
  */
-class EqualizerTreble extends DeviceAttribute {
+export default class EqualizerTreble extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -42,5 +42,3 @@ class EqualizerTreble extends DeviceAttribute {
     ];
   }
 }
-
-module.exports = EqualizerTreble;

--- a/lambda/alexa/smarthome/device/attributes/fanDirection.js
+++ b/lambda/alexa/smarthome/device/attributes/fanDirection.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const DeviceAttribute = require('./attribute');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines fan direction attribute class
  * @extends DeviceAttribute
  */
-class FanDirection extends DeviceAttribute {
+export default class FanDirection extends DeviceAttribute {
   /**
    * Defines forward direction
    * @type {String}
@@ -101,5 +101,3 @@ class FanDirection extends DeviceAttribute {
     }
   }
 }
-
-module.exports = FanDirection;

--- a/lambda/alexa/smarthome/device/attributes/fanOscillate.js
+++ b/lambda/alexa/smarthome/device/attributes/fanOscillate.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines fan oscillate attribute class
  * @extends DeviceAttribute
  */
-class FanOscillate extends DeviceAttribute {
+export default class FanOscillate extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -61,5 +61,3 @@ class FanOscillate extends DeviceAttribute {
     }
   }
 }
-
-module.exports = FanOscillate;

--- a/lambda/alexa/smarthome/device/attributes/fanSpeed.js
+++ b/lambda/alexa/smarthome/device/attributes/fanSpeed.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines fan speed attribute class
  * @extends DeviceAttribute
  */
-class FanSpeed extends DeviceAttribute {
+export default class FanSpeed extends DeviceAttribute {
   /**
    * Defines off speed
    * @type {String}
@@ -154,5 +154,3 @@ class FanSpeed extends DeviceAttribute {
     }
   }
 }
-
-module.exports = FanSpeed;

--- a/lambda/alexa/smarthome/device/attributes/fireAlarm.js
+++ b/lambda/alexa/smarthome/device/attributes/fireAlarm.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines fire alarm attribute class
  * @extends DeviceAttribute
  */
-class FireAlarm extends DeviceAttribute {
+export default class FireAlarm extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class FireAlarm extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.FIRE_ALARM }];
   }
 }
-
-module.exports = FireAlarm;

--- a/lambda/alexa/smarthome/device/attributes/heatingCoolingMode.js
+++ b/lambda/alexa/smarthome/device/attributes/heatingCoolingMode.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines heating/cooling mode attribute class
  * @extends DeviceAttribute
  */
-class HeatingCoolingMode extends DeviceAttribute {
+export default class HeatingCoolingMode extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -49,5 +49,3 @@ class HeatingCoolingMode extends DeviceAttribute {
     ];
   }
 }
-
-module.exports = HeatingCoolingMode;

--- a/lambda/alexa/smarthome/device/attributes/heatingSetpoint.js
+++ b/lambda/alexa/smarthome/device/attributes/heatingSetpoint.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const Temperature = require('./temperature');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import Temperature from './temperature.js';
 
 /**
  * Defines heating setpoint attribute class
  * @extends Temperature
  */
-class HeatingSetpoint extends Temperature {
+export default class HeatingSetpoint extends Temperature {
   /**
    * Returns supported names
    * @return {Array}
@@ -49,5 +49,3 @@ class HeatingSetpoint extends Temperature {
     ];
   }
 }
-
-module.exports = HeatingSetpoint;

--- a/lambda/alexa/smarthome/device/attributes/humidity.js
+++ b/lambda/alexa/smarthome/device/attributes/humidity.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines humidity attribute class
  * @extends DeviceAttribute
  */
-class Humidity extends DeviceAttribute {
+export default class Humidity extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -66,5 +66,3 @@ class Humidity extends DeviceAttribute {
     }
   }
 }
-
-module.exports = Humidity;

--- a/lambda/alexa/smarthome/device/attributes/index.js
+++ b/lambda/alexa/smarthome/device/attributes/index.js
@@ -11,82 +11,74 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-/**
- * Defines supported device attribute classes
- * @type {Object}
- */
-module.exports = {
-  AlarmAlert: require('./alarmAlert'),
-  ArmState: require('./armState'),
-  BatteryLevel: require('./batteryLevel'),
-  Brightness: require('./brightness'),
-  BurglaryAlarm: require('./burglaryAlarm'),
-  CameraStream: require('./cameraStream'),
-  CarbonMonoxideAlarm: require('./carbonMonoxideAlarm'),
-  Channel: require('./channel'),
-  ChannelStep: require('./channelStep'),
-  Color: require('./color'),
-  ColorTemperature: require('./colorTemperature'),
-  ContactDetectionState: require('./contactDetectionState'),
-  CoolingSetpoint: require('./coolingSetpoint'),
-  CurrentLockState: require('./currentLockState'),
-  CurrentOpenState: require('./currentOpenState'),
-  EcoCoolingSetpoint: require('./ecoCoolingSetpoint'),
-  EcoHeatingSetpoint: require('./ecoHeatingSetpoint'),
-  EqualizerBass: require('./equalizerBass'),
-  EqualizerMidrange: require('./equalizerMidrange'),
-  EqualizerMode: require('./equalizerMode'),
-  EqualizerTreble: require('./equalizerTreble'),
-  FanDirection: require('./fanDirection'),
-  FanOscillate: require('./fanOscillate'),
-  FanSpeed: require('./fanSpeed'),
-  FireAlarm: require('./fireAlarm'),
-  HeatingCoolingMode: require('./heatingCoolingMode'),
-  HeatingSetpoint: require('./heatingSetpoint'),
-  Humidity: require('./humidity'),
-  Input: require('./input'),
-  LockState: require('./lockState'),
-  Mode: require('./mode'),
-  MotionDetectionState: require('./motionDetectionState'),
-  MuteState: require('./muteState'),
-  MuteStep: require('./muteStep'),
-  NetworkAccess: require('./networkAccess'),
-  ObstacleAlert: require('./obstacleAlert'),
-  OpenState: require('./openState'),
-  Percentage: require('./percentage'),
-  Playback: require('./playback'),
-  PlaybackStop: require('./playbackStop'),
-  PositionState: require('./positionState'),
-  PowerLevel: require('./powerLevel'),
-  PowerState: require('./powerState'),
-  RangeValue: require('./rangeValue'),
-  ReadyAlert: require('./readyAlert'),
-  Scene: require('./scene'),
-  TargetTemperature: require('./targetTemperature'),
-  Temperature: require('./temperature'),
-  ThermostatFan: require('./thermostatFan'),
-  ThermostatHold: require('./thermostatHold'),
-  TiltAngle: require('./tiltAngle'),
-  ToggleState: require('./toggleState'),
-  TroubleAlert: require('./troubleAlert'),
-  VacuumMode: require('./vacuumMode'),
-  VolumeLevel: require('./volumeLevel'),
-  VolumeStep: require('./volumeStep'),
-  WaterAlarm: require('./waterAlarm'),
-  ZonesAlert: require('./zonesAlert')
-};
+import Mode from './mode.js';
+import RangeValue from './rangeValue.js';
+import ToggleState from './toggleState.js';
 
 /**
- * Returns device generic attributes
+ * Defines device generic attributes
  * @type {Array}
  */
-module.exports.genericAttributes = [require('./mode'), require('./rangeValue'), require('./toggleState')];
+export const genericAttributes = [Mode, RangeValue, ToggleState];
 
 /**
- * Returns device attribute based on given name
- * @param  {String} name
- * @return {Object}
+ * Exports supported device attribute classes
  */
-module.exports.get = function (name) {
-  return Object.values(this).find((deviceAttribute) => deviceAttribute.supportedNames?.includes(name));
-};
+export { default as AlarmAlert } from './alarmAlert.js';
+export { default as ArmState } from './armState.js';
+export { default as BatteryLevel } from './batteryLevel.js';
+export { default as Brightness } from './brightness.js';
+export { default as BurglaryAlarm } from './burglaryAlarm.js';
+export { default as CameraStream } from './cameraStream.js';
+export { default as CarbonMonoxideAlarm } from './carbonMonoxideAlarm.js';
+export { default as Channel } from './channel.js';
+export { default as ChannelStep } from './channelStep.js';
+export { default as Color } from './color.js';
+export { default as ColorTemperature } from './colorTemperature.js';
+export { default as ContactDetectionState } from './contactDetectionState.js';
+export { default as CoolingSetpoint } from './coolingSetpoint.js';
+export { default as CurrentLockState } from './currentLockState.js';
+export { default as CurrentOpenState } from './currentOpenState.js';
+export { default as EcoCoolingSetpoint } from './ecoCoolingSetpoint.js';
+export { default as EcoHeatingSetpoint } from './ecoHeatingSetpoint.js';
+export { default as EqualizerBass } from './equalizerBass.js';
+export { default as EqualizerMidrange } from './equalizerMidrange.js';
+export { default as EqualizerMode } from './equalizerMode.js';
+export { default as EqualizerTreble } from './equalizerTreble.js';
+export { default as FanDirection } from './fanDirection.js';
+export { default as FanOscillate } from './fanOscillate.js';
+export { default as FanSpeed } from './fanSpeed.js';
+export { default as FireAlarm } from './fireAlarm.js';
+export { default as HeatingCoolingMode } from './heatingCoolingMode.js';
+export { default as HeatingSetpoint } from './heatingSetpoint.js';
+export { default as Humidity } from './humidity.js';
+export { default as Input } from './input.js';
+export { default as LockState } from './lockState.js';
+export { default as Mode } from './mode.js';
+export { default as MotionDetectionState } from './motionDetectionState.js';
+export { default as MuteState } from './muteState.js';
+export { default as MuteStep } from './muteStep.js';
+export { default as NetworkAccess } from './networkAccess.js';
+export { default as ObstacleAlert } from './obstacleAlert.js';
+export { default as OpenState } from './openState.js';
+export { default as Percentage } from './percentage.js';
+export { default as Playback } from './playback.js';
+export { default as PlaybackStop } from './playbackStop.js';
+export { default as PositionState } from './positionState.js';
+export { default as PowerLevel } from './powerLevel.js';
+export { default as PowerState } from './powerState.js';
+export { default as RangeValue } from './rangeValue.js';
+export { default as ReadyAlert } from './readyAlert.js';
+export { default as Scene } from './scene.js';
+export { default as TargetTemperature } from './targetTemperature.js';
+export { default as Temperature } from './temperature.js';
+export { default as ThermostatFan } from './thermostatFan.js';
+export { default as ThermostatHold } from './thermostatHold.js';
+export { default as TiltAngle } from './tiltAngle.js';
+export { default as ToggleState } from './toggleState.js';
+export { default as TroubleAlert } from './troubleAlert.js';
+export { default as VacuumMode } from './vacuumMode.js';
+export { default as VolumeLevel } from './volumeLevel.js';
+export { default as VolumeStep } from './volumeStep.js';
+export { default as WaterAlarm } from './waterAlarm.js';
+export { default as ZonesAlert } from './zonesAlert.js';

--- a/lambda/alexa/smarthome/device/attributes/input.js
+++ b/lambda/alexa/smarthome/device/attributes/input.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines input attribute class
  * @extends DeviceAttribute
  */
-class Input extends DeviceAttribute {
+export default class Input extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -68,5 +68,3 @@ class Input extends DeviceAttribute {
     }
   }
 }
-
-module.exports = Input;

--- a/lambda/alexa/smarthome/device/attributes/lockState.js
+++ b/lambda/alexa/smarthome/device/attributes/lockState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines lock state attribute class
  * @extends DeviceAttribute
  */
-class LockState extends DeviceAttribute {
+export default class LockState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class LockState extends DeviceAttribute {
     return [{ name: Capability.LOCK_CONTROLLER, property: Property.LOCK_STATE, tag: this.tag }];
   }
 }
-
-module.exports = LockState;

--- a/lambda/alexa/smarthome/device/attributes/mode.js
+++ b/lambda/alexa/smarthome/device/attributes/mode.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines mode attribute class
  * @extends DeviceAttribute
  */
-class Mode extends DeviceAttribute {
+export default class Mode extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -57,5 +57,3 @@ class Mode extends DeviceAttribute {
     }
   }
 }
-
-module.exports = Mode;

--- a/lambda/alexa/smarthome/device/attributes/motionDetectionState.js
+++ b/lambda/alexa/smarthome/device/attributes/motionDetectionState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines motion detection state attribute class
  * @extends DeviceAttribute
  */
-class MotionDetectionState extends DeviceAttribute {
+export default class MotionDetectionState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class MotionDetectionState extends DeviceAttribute {
     return [{ name: Capability.MOTION_SENSOR, property: Property.DETECTION_STATE }];
   }
 }
-
-module.exports = MotionDetectionState;

--- a/lambda/alexa/smarthome/device/attributes/muteState.js
+++ b/lambda/alexa/smarthome/device/attributes/muteState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines mute state attribute class
  * @extends DeviceAttribute
  */
-class MuteState extends DeviceAttribute {
+export default class MuteState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -38,5 +38,3 @@ class MuteState extends DeviceAttribute {
     return [{ name: Capability.SPEAKER, property: Property.MUTED }];
   }
 }
-
-module.exports = MuteState;

--- a/lambda/alexa/smarthome/device/attributes/muteStep.js
+++ b/lambda/alexa/smarthome/device/attributes/muteStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines mute step attribute class
  * @extends DeviceAttribute
  */
-class MuteStep extends DeviceAttribute {
+export default class MuteStep extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class MuteStep extends DeviceAttribute {
     return [{ name: Capability.STEP_SPEAKER, property: Property.MUTED }];
   }
 }
-
-module.exports = MuteStep;

--- a/lambda/alexa/smarthome/device/attributes/networkAccess.js
+++ b/lambda/alexa/smarthome/device/attributes/networkAccess.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines network access attribute class
  * @extends DeviceAttribute
  */
-class NetworkAccess extends DeviceAttribute {
+export default class NetworkAccess extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class NetworkAccess extends DeviceAttribute {
     return [{ name: Capability.NETWORKING_ACCESS_CONTROLLER, property: Property.NETWORK_ACCESS }];
   }
 }
-
-module.exports = NetworkAccess;

--- a/lambda/alexa/smarthome/device/attributes/obstacleAlert.js
+++ b/lambda/alexa/smarthome/device/attributes/obstacleAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines obstacle alert attribute class
  * @extends DeviceAttribute
  */
-class ObstacleAlert extends DeviceAttribute {
+export default class ObstacleAlert extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ObstacleAlert extends DeviceAttribute {
     return [{ name: Capability.SAFETY, property: Property.OBSTACLE_ALERT }];
   }
 }
-
-module.exports = ObstacleAlert;

--- a/lambda/alexa/smarthome/device/attributes/openState.js
+++ b/lambda/alexa/smarthome/device/attributes/openState.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const DecoupleState = require('@alexa/smarthome/properties/decoupleState');
-const { AlexaActionSemantic, AlexaStateSemantic } = require('@alexa/smarthome/semantics');
-const DeviceAttribute = require('./attribute');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import { DecoupleState } from '#alexa/smarthome/properties/index.js';
+import { AlexaActionSemantic, AlexaStateSemantic } from '#alexa/smarthome/semantics.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines open state attribute class
  * @extends DeviceAttribute
  */
-class OpenState extends DeviceAttribute {
+export default class OpenState extends DeviceAttribute {
   /**
    * Defines open state
    * @type {String}
@@ -114,5 +114,3 @@ class OpenState extends DeviceAttribute {
     }
   }
 }
-
-module.exports = OpenState;

--- a/lambda/alexa/smarthome/device/attributes/percentage.js
+++ b/lambda/alexa/smarthome/device/attributes/percentage.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines percentage attribute class
  * @extends DeviceAttribute
  */
-class Percentage extends DeviceAttribute {
+export default class Percentage extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Percentage extends DeviceAttribute {
     return [{ name: Capability.PERCENTAGE_CONTROLLER, property: Property.PERCENTAGE }];
   }
 }
-
-module.exports = Percentage;

--- a/lambda/alexa/smarthome/device/attributes/playback.js
+++ b/lambda/alexa/smarthome/device/attributes/playback.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines playback attribute class
  * @extends DeviceAttribute
  */
-class Playback extends DeviceAttribute {
+export default class Playback extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -38,5 +38,3 @@ class Playback extends DeviceAttribute {
     return [{ name: Capability.PLAYBACK_CONTROLLER, property: Property.PLAYBACK }];
   }
 }
-
-module.exports = Playback;

--- a/lambda/alexa/smarthome/device/attributes/playbackStop.js
+++ b/lambda/alexa/smarthome/device/attributes/playbackStop.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines playback stop attribute class
  * @extends DeviceAttribute
  */
-class PlaybackStop extends DeviceAttribute {
+export default class PlaybackStop extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class PlaybackStop extends DeviceAttribute {
     return [{ name: Capability.PLAYBACK_CONTROLLER, property: Property.PLAYBACK_STOP }];
   }
 }
-
-module.exports = PlaybackStop;

--- a/lambda/alexa/smarthome/device/attributes/positionState.js
+++ b/lambda/alexa/smarthome/device/attributes/positionState.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } = require('@alexa/smarthome/semantics');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } from '#alexa/smarthome/semantics.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines position state attribute class
  * @extends DeviceAttribute
  */
-class PositionState extends DeviceAttribute {
+export default class PositionState extends DeviceAttribute {
   /**
    * Defines position primary control
    * @type {String}
@@ -178,5 +178,3 @@ class PositionState extends DeviceAttribute {
     }
   }
 }
-
-module.exports = PositionState;

--- a/lambda/alexa/smarthome/device/attributes/powerLevel.js
+++ b/lambda/alexa/smarthome/device/attributes/powerLevel.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines power level attribute class
  * @extends DeviceAttribute
  */
-class PowerLevel extends DeviceAttribute {
+export default class PowerLevel extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class PowerLevel extends DeviceAttribute {
     return [{ name: Capability.POWER_LEVEL_CONTROLLER, property: Property.POWER_LEVEL }];
   }
 }
-
-module.exports = PowerLevel;

--- a/lambda/alexa/smarthome/device/attributes/powerState.js
+++ b/lambda/alexa/smarthome/device/attributes/powerState.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines power state attribute class
  * @extends DeviceAttribute
  */
-class PowerState extends DeviceAttribute {
+export default class PowerState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class PowerState extends DeviceAttribute {
     return [{ name: Capability.POWER_CONTROLLER, property: Property.POWER_STATE }];
   }
 }
-
-module.exports = PowerState;

--- a/lambda/alexa/smarthome/device/attributes/rangeValue.js
+++ b/lambda/alexa/smarthome/device/attributes/rangeValue.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines range value attribute class
  * @extends DeviceAttribute
  */
-class RangeValue extends DeviceAttribute {
+export default class RangeValue extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -68,5 +68,3 @@ class RangeValue extends DeviceAttribute {
     }
   }
 }
-
-module.exports = RangeValue;

--- a/lambda/alexa/smarthome/device/attributes/readyAlert.js
+++ b/lambda/alexa/smarthome/device/attributes/readyAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines ready alert attribute class
  * @extends DeviceAttribute
  */
-class ReadyAlert extends DeviceAttribute {
+export default class ReadyAlert extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ReadyAlert extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.READY_ALERT }];
   }
 }
-
-module.exports = ReadyAlert;

--- a/lambda/alexa/smarthome/device/attributes/scene.js
+++ b/lambda/alexa/smarthome/device/attributes/scene.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines scene attribute class
  * @extends DeviceAttribute
  */
-class Scene extends DeviceAttribute {
+export default class Scene extends DeviceAttribute {
   /**
    * Returns capabilities
    * @return {Array}
@@ -27,5 +27,3 @@ class Scene extends DeviceAttribute {
     return [{ name: Capability.SCENE_CONTROLLER, property: Property.SCENE }];
   }
 }
-
-module.exports = Scene;

--- a/lambda/alexa/smarthome/device/attributes/targetTemperature.js
+++ b/lambda/alexa/smarthome/device/attributes/targetTemperature.js
@@ -11,20 +11,20 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const TargetSetpoint = require('@alexa/smarthome/properties/targetSetpoint');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const Temperature = require('./temperature');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import { TargetSetpoint } from '#alexa/smarthome/properties/index.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import Temperature from './temperature.js';
 
 /**
  * Defines target temperature attribute class
  * @extends Temperature
  */
-class TargetTemperature extends Temperature {
+export default class TargetTemperature extends Temperature {
   /**
    * Returns supported names
    * @return {Array}
@@ -92,5 +92,3 @@ class TargetTemperature extends Temperature {
     }
   }
 }
-
-module.exports = TargetTemperature;

--- a/lambda/alexa/smarthome/device/attributes/temperature.js
+++ b/lambda/alexa/smarthome/device/attributes/temperature.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Dimension, ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter } = require('@alexa/smarthome/metadata');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { Dimension, ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter } from '#alexa/smarthome/metadata.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines temperature attribute class
  * @extends DeviceAttribute
  */
-class Temperature extends DeviceAttribute {
+export default class Temperature extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -118,5 +118,3 @@ class Temperature extends DeviceAttribute {
       .find((value) => value === AlexaUnitOfMeasure.UNIT_CELSIUS || value === AlexaUnitOfMeasure.UNIT_FAHRENHEIT);
   }
 }
-
-module.exports = Temperature;

--- a/lambda/alexa/smarthome/device/attributes/thermostatFan.js
+++ b/lambda/alexa/smarthome/device/attributes/thermostatFan.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines thermostat fan attribute class
  * @extends DeviceAttribute
  */
-class ThermostatFan extends DeviceAttribute {
+export default class ThermostatFan extends DeviceAttribute {
   /**
    * Defines fan auto
    * @type {String}
@@ -89,5 +89,3 @@ class ThermostatFan extends DeviceAttribute {
     }
   }
 }
-
-module.exports = ThermostatFan;

--- a/lambda/alexa/smarthome/device/attributes/thermostatHold.js
+++ b/lambda/alexa/smarthome/device/attributes/thermostatHold.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines thermostat hold attribute class
  * @extends DeviceAttribute
  */
-class ThermostatHold extends DeviceAttribute {
+export default class ThermostatHold extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ThermostatHold extends DeviceAttribute {
     return [{ name: Capability.THERMOSTAT_CONTROLLER, property: Property.THERMOSTAT_HOLD }];
   }
 }
-
-module.exports = ThermostatHold;

--- a/lambda/alexa/smarthome/device/attributes/tiltAngle.js
+++ b/lambda/alexa/smarthome/device/attributes/tiltAngle.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { Parameter, ParameterType } = require('@alexa/smarthome/metadata');
-const { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } = require('@alexa/smarthome/semantics');
-const AlexaUnitOfMeasure = require('@alexa/smarthome/unitOfMeasure');
-const DeviceAttribute = require('./attribute');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { Parameter, ParameterType } from '#alexa/smarthome/metadata.js';
+import { AlexaActionSemantic, AlexaStateSemantic, CustomActionSemantic } from '#alexa/smarthome/semantics.js';
+import AlexaUnitOfMeasure from '#alexa/smarthome/unitOfMeasure.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines tilt angle attribute class
  * @extends DeviceAttribute
  */
-class TiltAngle extends DeviceAttribute {
+export default class TiltAngle extends DeviceAttribute {
   /**
    * Defines tilt primary control
    * @type {String}
@@ -169,5 +169,3 @@ class TiltAngle extends DeviceAttribute {
     }
   }
 }
-
-module.exports = TiltAngle;

--- a/lambda/alexa/smarthome/device/attributes/toggleState.js
+++ b/lambda/alexa/smarthome/device/attributes/toggleState.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines toggle state attribute class
  * @extends DeviceAttribute
  */
-class ToggleState extends DeviceAttribute {
+export default class ToggleState extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -51,5 +51,3 @@ class ToggleState extends DeviceAttribute {
     }
   }
 }
-
-module.exports = ToggleState;

--- a/lambda/alexa/smarthome/device/attributes/troubleAlert.js
+++ b/lambda/alexa/smarthome/device/attributes/troubleAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines trouble alert attribute class
  * @extends DeviceAttribute
  */
-class TroubleAlert extends DeviceAttribute {
+export default class TroubleAlert extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class TroubleAlert extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.TROUBLE_ALERT }];
   }
 }
-
-module.exports = TroubleAlert;

--- a/lambda/alexa/smarthome/device/attributes/vacuumMode.js
+++ b/lambda/alexa/smarthome/device/attributes/vacuumMode.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaAssetCatalog = require('@alexa/smarthome/catalog');
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const { CustomActionSemantic } = require('@alexa/smarthome/semantics');
-const DeviceAttribute = require('./attribute');
+import { ItemType } from '#openhab/constants.js';
+import AlexaAssetCatalog from '#alexa/smarthome/catalog.js';
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import { CustomActionSemantic } from '#alexa/smarthome/semantics.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines vacuum mode attribute class
  * @extends DeviceAttribute
  */
-class VacuumMode extends DeviceAttribute {
+export default class VacuumMode extends DeviceAttribute {
   /**
    * Defines clean mode
    * @type {String}
@@ -156,5 +156,3 @@ class VacuumMode extends DeviceAttribute {
     }
   }
 }
-
-module.exports = VacuumMode;

--- a/lambda/alexa/smarthome/device/attributes/volumeLevel.js
+++ b/lambda/alexa/smarthome/device/attributes/volumeLevel.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines volume level attribute class
  * @extends DeviceAttribute
  */
-class VolumeLevel extends DeviceAttribute {
+export default class VolumeLevel extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -38,5 +38,3 @@ class VolumeLevel extends DeviceAttribute {
     return [{ name: Capability.SPEAKER, property: Property.VOLUME }];
   }
 }
-
-module.exports = VolumeLevel;

--- a/lambda/alexa/smarthome/device/attributes/volumeStep.js
+++ b/lambda/alexa/smarthome/device/attributes/volumeStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines volume step attribute class
  * @extends DeviceAttribute
  */
-class VolumeStep extends DeviceAttribute {
+export default class VolumeStep extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class VolumeStep extends DeviceAttribute {
     return [{ name: Capability.STEP_SPEAKER, property: Property.VOLUME }];
   }
 }
-
-module.exports = VolumeStep;

--- a/lambda/alexa/smarthome/device/attributes/waterAlarm.js
+++ b/lambda/alexa/smarthome/device/attributes/waterAlarm.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines water alarm attribute class
  * @extends DeviceAttribute
  */
-class WaterAlarm extends DeviceAttribute {
+export default class WaterAlarm extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class WaterAlarm extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.WATER_ALARM }];
   }
 }
-
-module.exports = WaterAlarm;

--- a/lambda/alexa/smarthome/device/attributes/zonesAlert.js
+++ b/lambda/alexa/smarthome/device/attributes/zonesAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const DeviceAttribute = require('./attribute');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import DeviceAttribute from './attribute.js';
 
 /**
  * Defines zones alert attribute class
  * @extends DeviceAttribute
  */
-class ZonesAlert extends DeviceAttribute {
+export default class ZonesAlert extends DeviceAttribute {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ZonesAlert extends DeviceAttribute {
     return [{ name: Capability.SECURITY_PANEL_CONTROLLER, property: Property.ZONES_ALERT }];
   }
 }
-
-module.exports = ZonesAlert;

--- a/lambda/alexa/smarthome/device/types/activity.js
+++ b/lambda/alexa/smarthome/device/types/activity.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Scene = require('./scene');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Scene from './scene.js';
 
 /**
  * Defines activity device type class
  * @extends Scene
  */
-class Activity extends Scene {
+export default class Activity extends Scene {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Activity extends Scene {
     return [AlexaDisplayCategory.ACTIVITY_TRIGGER];
   }
 }
-
-module.exports = Activity;

--- a/lambda/alexa/smarthome/device/types/airConditioner.js
+++ b/lambda/alexa/smarthome/device/types/airConditioner.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Fan = require('./fan');
-const { TargetTemperature, Temperature, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Fan from './fan.js';
+import { TargetTemperature, Temperature, PowerState } from '../attributes/index.js';
 
 /**
  * Defines air conditioner device type class
  * @extends Fan
  */
-class AirConditioner extends Fan {
+export default class AirConditioner extends Fan {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class AirConditioner extends Fan {
     return [AlexaDisplayCategory.AIR_CONDITIONER];
   }
 }
-
-module.exports = AirConditioner;

--- a/lambda/alexa/smarthome/device/types/airFreshener.js
+++ b/lambda/alexa/smarthome/device/types/airFreshener.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Fan = require('./fan');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Fan from './fan.js';
 
 /**
  * Defines air freshener device type class
  * @extends Fan
  */
-class AirFreshner extends Fan {
+export default class AirFreshner extends Fan {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class AirFreshner extends Fan {
     return [AlexaDisplayCategory.AIR_FRESHENER];
   }
 }
-
-module.exports = AirFreshner;

--- a/lambda/alexa/smarthome/device/types/airPurifier.js
+++ b/lambda/alexa/smarthome/device/types/airPurifier.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Fan = require('./fan');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Fan from './fan.js';
 
 /**
  * Defines air purifier device type class
  * @extends Fan
  */
-class AirPurifier extends Fan {
+export default class AirPurifier extends Fan {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class AirPurifier extends Fan {
     return [AlexaDisplayCategory.AIR_PURIFIER];
   }
 }
-
-module.exports = AirPurifier;

--- a/lambda/alexa/smarthome/device/types/automobile.js
+++ b/lambda/alexa/smarthome/device/types/automobile.js
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const {
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import {
   BatteryLevel,
   FanSpeed,
   LockState,
@@ -21,13 +21,13 @@ const {
   TargetTemperature,
   Temperature,
   genericAttributes
-} = require('../attributes');
+} from '../attributes/index.js';
 
 /**
  * Defines automobile device type class
  * @extends DeviceType
  */
-class Automobile extends DeviceType {
+export default class Automobile extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Automobile extends DeviceType {
     return [AlexaDisplayCategory.VEHICLE];
   }
 }
-
-module.exports = Automobile;

--- a/lambda/alexa/smarthome/device/types/automobileAccessory.js
+++ b/lambda/alexa/smarthome/device/types/automobileAccessory.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const { BatteryLevel, CameraStream, FanSpeed, PowerState, genericAttributes } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import { BatteryLevel, CameraStream, FanSpeed, PowerState, genericAttributes } from '../attributes/index.js';
 
 /**
  * Defines automobile accessory device type class
  * @extends DeviceType
  */
-class AutomobileAccessory extends DeviceType {
+export default class AutomobileAccessory extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class AutomobileAccessory extends DeviceType {
     return [AlexaDisplayCategory.AUTO_ACCESSORY];
   }
 }
-
-module.exports = AutomobileAccessory;

--- a/lambda/alexa/smarthome/device/types/bluetoothSpeaker.js
+++ b/lambda/alexa/smarthome/device/types/bluetoothSpeaker.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Speaker = require('./speaker');
-const { BatteryLevel } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Speaker from './speaker.js';
+import { BatteryLevel } from '../attributes/index.js';
 
 /**
  * Defines bluetooth speaker device type class
  * @extends Speaker
  */
-class BluetoothSpeaker extends Speaker {
+export default class BluetoothSpeaker extends Speaker {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class BluetoothSpeaker extends Speaker {
     return [AlexaDisplayCategory.BLUETOOTH_SPEAKER];
   }
 }
-
-module.exports = BluetoothSpeaker;

--- a/lambda/alexa/smarthome/device/types/camera.js
+++ b/lambda/alexa/smarthome/device/types/camera.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { CameraStream, BatteryLevel, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { CameraStream, BatteryLevel, PowerState } from '../attributes/index.js';
 
 /**
  * Defines camera device type class
  * @extends GenericDevice
  */
-class Camera extends GenericDevice {
+export default class Camera extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Camera extends GenericDevice {
     return [AlexaDisplayCategory.CAMERA];
   }
 }
-
-module.exports = Camera;

--- a/lambda/alexa/smarthome/device/types/christmasTree.js
+++ b/lambda/alexa/smarthome/device/types/christmasTree.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Light = require('./light');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Light from './light.js';
 
 /**
  * Defines christmas tree device type class
  * @extends Light
  */
-class ChristmasTree extends Light {
+export default class ChristmasTree extends Light {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ChristmasTree extends Light {
     return [AlexaDisplayCategory.CHRISTMAS_TREE];
   }
 }
-
-module.exports = ChristmasTree;

--- a/lambda/alexa/smarthome/device/types/coffeeMaker.js
+++ b/lambda/alexa/smarthome/device/types/coffeeMaker.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines coffee maker device type class
  * @extends GenericDevice
  */
-class CoffeeMaker extends GenericDevice {
+export default class CoffeeMaker extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class CoffeeMaker extends GenericDevice {
     return [AlexaDisplayCategory.COFFEE_MAKER];
   }
 }
-
-module.exports = CoffeeMaker;

--- a/lambda/alexa/smarthome/device/types/computer.js
+++ b/lambda/alexa/smarthome/device/types/computer.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const NetworkDevice = require('./networkDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import NetworkDevice from './networkDevice.js';
 
 /**
  * Defines computer device type class
  * @extends NetworkDevice
  */
-class Computer extends NetworkDevice {
+export default class Computer extends NetworkDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Computer extends NetworkDevice {
     return [AlexaDisplayCategory.COMPUTER];
   }
 }
-
-module.exports = Computer;

--- a/lambda/alexa/smarthome/device/types/contactSensor.js
+++ b/lambda/alexa/smarthome/device/types/contactSensor.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Sensor = require('./sensor');
-const { ContactDetectionState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Sensor from './sensor.js';
+import { ContactDetectionState } from '../attributes/index.js';
 
 /**
  * Defines contact sensor device type class
  * @extends Sensor
  */
-class ContactSensor extends Sensor {
+export default class ContactSensor extends Sensor {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class ContactSensor extends Sensor {
     return [AlexaDisplayCategory.CONTACT_SENSOR];
   }
 }
-
-module.exports = ContactSensor;

--- a/lambda/alexa/smarthome/device/types/dishwasher.js
+++ b/lambda/alexa/smarthome/device/types/dishwasher.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines dishwasher device type class
  * @extends GenericDevice
  */
-class Dishwasher extends GenericDevice {
+export default class Dishwasher extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Dishwasher extends GenericDevice {
     return [AlexaDisplayCategory.DISHWASHER];
   }
 }
-
-module.exports = Dishwasher;

--- a/lambda/alexa/smarthome/device/types/door.js
+++ b/lambda/alexa/smarthome/device/types/door.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const { OpenState, CurrentOpenState, genericAttributes } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import { OpenState, CurrentOpenState, genericAttributes } from '../attributes/index.js';
 
 /**
  * Defines door device type class
  * @extends DeviceType
  */
-class Door extends DeviceType {
+export default class Door extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Door extends DeviceType {
     return [AlexaDisplayCategory.DOOR];
   }
 }
-
-module.exports = Door;

--- a/lambda/alexa/smarthome/device/types/doorbell.js
+++ b/lambda/alexa/smarthome/device/types/doorbell.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Camera = require('./camera');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Camera from './camera.js';
 
 /**
  * Defines doorbell device type class
  * @extends Camera
  */
-class Doorbell extends Camera {
+export default class Doorbell extends Camera {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Doorbell extends Camera {
     return [AlexaDisplayCategory.DOORBELL];
   }
 }
-
-module.exports = Doorbell;

--- a/lambda/alexa/smarthome/device/types/dryer.js
+++ b/lambda/alexa/smarthome/device/types/dryer.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines dryer device type class
  * @extends GenericDevice
  */
-class Dryer extends GenericDevice {
+export default class Dryer extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Dryer extends GenericDevice {
     return [AlexaDisplayCategory.DRYER];
   }
 }
-
-module.exports = Dryer;

--- a/lambda/alexa/smarthome/device/types/dummy.js
+++ b/lambda/alexa/smarthome/device/types/dummy.js
@@ -11,12 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const DeviceType = require('./type');
+import DeviceType from './type.js';
 
 /**
  * Defines dummy device type class
  * @extends DeviceType
  */
-class Dummy extends DeviceType {}
-
-module.exports = Dummy;
+export default class Dummy extends DeviceType {}

--- a/lambda/alexa/smarthome/device/types/entertainment.js
+++ b/lambda/alexa/smarthome/device/types/entertainment.js
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const GenericDevice = require('./genericDevice');
-const {
+import GenericDevice from './genericDevice.js';
+import {
   VolumeLevel,
   VolumeStep,
   MuteState,
@@ -26,13 +26,13 @@ const {
   EqualizerMidrange,
   EqualizerTreble,
   EqualizerMode
-} = require('../attributes');
+} from '../attributes/index.js';
 
 /**
  * Defines entertainment device type class
  * @extends GenericDevice
  */
-class Entertainment extends GenericDevice {
+export default class Entertainment extends GenericDevice {
   /**
    * Returns supported attributes
    * @return {Array}
@@ -56,5 +56,3 @@ class Entertainment extends GenericDevice {
     ];
   }
 }
-
-module.exports = Entertainment;

--- a/lambda/alexa/smarthome/device/types/exteriorBlind.js
+++ b/lambda/alexa/smarthome/device/types/exteriorBlind.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const InteriorBlind = require('./interiorBlind');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import InteriorBlind from './interiorBlind.js';
 
 /**
  * Defines external blind device type class
  * @extends InteriorBlind
  */
-class ExteriorBlind extends InteriorBlind {
+export default class ExteriorBlind extends InteriorBlind {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class ExteriorBlind extends InteriorBlind {
     return [AlexaDisplayCategory.EXTERIOR_BLIND];
   }
 }
-
-module.exports = ExteriorBlind;

--- a/lambda/alexa/smarthome/device/types/fan.js
+++ b/lambda/alexa/smarthome/device/types/fan.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { FanDirection, FanOscillate, FanSpeed, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { FanDirection, FanOscillate, FanSpeed, PowerState } from '../attributes/index.js';
 
 /**
  * Defines fan device type class
  * @extends GenericDevice
  */
-class Fan extends GenericDevice {
+export default class Fan extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Fan extends GenericDevice {
     return [AlexaDisplayCategory.FAN];
   }
 }
-
-module.exports = Fan;

--- a/lambda/alexa/smarthome/device/types/gameConsole.js
+++ b/lambda/alexa/smarthome/device/types/gameConsole.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const NetworkDevice = require('./networkDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import NetworkDevice from './networkDevice.js';
 
 /**
  * Defines game console device type class
  * @extends NetworkDevice
  */
-class GameConsole extends NetworkDevice {
+export default class GameConsole extends NetworkDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class GameConsole extends NetworkDevice {
     return [AlexaDisplayCategory.GAME_CONSOLE];
   }
 }
-
-module.exports = GameConsole;

--- a/lambda/alexa/smarthome/device/types/garageDoor.js
+++ b/lambda/alexa/smarthome/device/types/garageDoor.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Door = require('./door');
-const { ObstacleAlert } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Door from './door.js';
+import { ObstacleAlert } from '../attributes/index.js';
 
 /**
  * Defines garage door device type class
  * @extends Door
  */
-class GarageDoor extends Door {
+export default class GarageDoor extends Door {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class GarageDoor extends Door {
     return [AlexaDisplayCategory.GARAGE_DOOR];
   }
 }
-
-module.exports = GarageDoor;

--- a/lambda/alexa/smarthome/device/types/genericDevice.js
+++ b/lambda/alexa/smarthome/device/types/genericDevice.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const DeviceType = require('./type');
-const { PowerState, genericAttributes } = require('../attributes');
+import DeviceType from './type.js';
+import { PowerState, genericAttributes } from '../attributes/index.js';
 
 /**
  * Defines generic device type class
  * @extends DeviceType
  */
-class GenericDevice extends DeviceType {
+export default class GenericDevice extends DeviceType {
   /**
    * Returns supported attributes
    * @return {Array}
@@ -35,5 +35,3 @@ class GenericDevice extends DeviceType {
     return [PowerState];
   }
 }
-
-module.exports = GenericDevice;

--- a/lambda/alexa/smarthome/device/types/headphones.js
+++ b/lambda/alexa/smarthome/device/types/headphones.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const BluetoothSpeaker = require('./bluetoothSpeaker');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import BluetoothSpeaker from './bluetoothSpeaker.js';
 
 /**
  * Defines headphones device type class
  * @extends BluetoothSpeaker
  */
-class Headphones extends BluetoothSpeaker {
+export default class Headphones extends BluetoothSpeaker {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Headphones extends BluetoothSpeaker {
     return [AlexaDisplayCategory.HEADPHONES];
   }
 }
-
-module.exports = Headphones;

--- a/lambda/alexa/smarthome/device/types/hub.js
+++ b/lambda/alexa/smarthome/device/types/hub.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines smarthome hub device type class
  * @extends GenericDevice
  */
-class Hub extends GenericDevice {
+export default class Hub extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Hub extends GenericDevice {
     return [AlexaDisplayCategory.HUB];
   }
 }
-
-module.exports = Hub;

--- a/lambda/alexa/smarthome/device/types/index.js
+++ b/lambda/alexa/smarthome/device/types/index.js
@@ -12,76 +12,59 @@
  */
 
 /**
- * Defines supported device types classes
- * @type {Object}
+ * Exports supported device type classes
  */
-module.exports = {
-  Activity: require('./activity'),
-  AirConditioner: require('./airConditioner'),
-  AirFreshener: require('./airFreshener'),
-  AirPurifier: require('./airPurifier'),
-  Automobile: require('./automobile'),
-  AutomobileAccessory: require('./automobileAccessory'),
-  BluetoothSpeaker: require('./bluetoothSpeaker'),
-  Camera: require('./camera'),
-  ChristmasTree: require('./christmasTree'),
-  CoffeeMaker: require('./coffeeMaker'),
-  Computer: require('./computer'),
-  ContactSensor: require('./contactSensor'),
-  Dishwasher: require('./dishwasher'),
-  Door: require('./door'),
-  Doorbell: require('./doorbell'),
-  Dummy: require('./dummy'),
-  Dryer: require('./dryer'),
-  ExteriorBlind: require('./exteriorBlind'),
-  Fan: require('./fan'),
-  GameConsole: require('./gameConsole'),
-  GarageDoor: require('./garageDoor'),
-  Headphones: require('./headphones'),
-  Hub: require('./hub'),
-  InteriorBlind: require('./interiorBlind'),
-  Laptop: require('./laptop'),
-  Light: require('./light'),
-  Lock: require('./lock'),
-  Microwave: require('./microwave'),
-  MobilePhone: require('./mobilePhone'),
-  MotionSensor: require('./motionSensor'),
-  MusicSystem: require('./musicSystem'),
-  NetworkHardware: require('./networkHardware'),
-  Other: require('./other'),
-  Outlet: require('./outlet'),
-  Oven: require('./oven'),
-  Phone: require('./phone'),
-  Printer: require('./printer'),
-  Router: require('./router'),
-  Scene: require('./scene'),
-  Screen: require('./screen'),
-  SecurityPanel: require('./securityPanel'),
-  SecuritySystem: require('./securitySystem'),
-  SlowCooker: require('./slowCooker'),
-  Speaker: require('./speaker'),
-  StreamingDevice: require('./streamingDevice'),
-  Switch: require('./switch'),
-  Tablet: require('./tablet'),
-  Television: require('./television'),
-  TemperatureSensor: require('./temperatureSensor'),
-  Thermostat: require('./thermostat'),
-  VacuumCleaner: require('./vacuumCleaner'),
-  Washer: require('./washer'),
-  WaterHeater: require('./waterHeater'),
-  Wearable: require('./wearable')
-};
-
-/**
- * Returns device type based on given name
- * @param  {String} name
- * @return {Object}
- */
-module.exports.get = function (name) {
-  return Object.values(this).find(
-    (deviceType) =>
-      deviceType.supportedNames?.includes(name) ||
-      // Fallback to display category for backward compatibility
-      deviceType.displayCategories?.includes(name)
-  );
-};
+export { default as Activity } from './activity.js';
+export { default as AirConditioner } from './airConditioner.js';
+export { default as AirFreshener } from './airFreshener.js';
+export { default as AirPurifier } from './airPurifier.js';
+export { default as Automobile } from './automobile.js';
+export { default as AutomobileAccessory } from './automobileAccessory.js';
+export { default as BluetoothSpeaker } from './bluetoothSpeaker.js';
+export { default as Camera } from './camera.js';
+export { default as ChristmasTree } from './christmasTree.js';
+export { default as CoffeeMaker } from './coffeeMaker.js';
+export { default as Computer } from './computer.js';
+export { default as ContactSensor } from './contactSensor.js';
+export { default as Dishwasher } from './dishwasher.js';
+export { default as Door } from './door.js';
+export { default as Doorbell } from './doorbell.js';
+export { default as Dummy } from './dummy.js';
+export { default as Dryer } from './dryer.js';
+export { default as ExteriorBlind } from './exteriorBlind.js';
+export { default as Fan } from './fan.js';
+export { default as GameConsole } from './gameConsole.js';
+export { default as GarageDoor } from './garageDoor.js';
+export { default as Headphones } from './headphones.js';
+export { default as Hub } from './hub.js';
+export { default as InteriorBlind } from './interiorBlind.js';
+export { default as Laptop } from './laptop.js';
+export { default as Light } from './light.js';
+export { default as Lock } from './lock.js';
+export { default as Microwave } from './microwave.js';
+export { default as MobilePhone } from './mobilePhone.js';
+export { default as MotionSensor } from './motionSensor.js';
+export { default as MusicSystem } from './musicSystem.js';
+export { default as NetworkHardware } from './networkHardware.js';
+export { default as Other } from './other.js';
+export { default as Outlet } from './outlet.js';
+export { default as Oven } from './oven.js';
+export { default as Phone } from './phone.js';
+export { default as Printer } from './printer.js';
+export { default as Router } from './router.js';
+export { default as Scene } from './scene.js';
+export { default as Screen } from './screen.js';
+export { default as SecurityPanel } from './securityPanel.js';
+export { default as SecuritySystem } from './securitySystem.js';
+export { default as SlowCooker } from './slowCooker.js';
+export { default as Speaker } from './speaker.js';
+export { default as StreamingDevice } from './streamingDevice.js';
+export { default as Switch } from './switch.js';
+export { default as Tablet } from './tablet.js';
+export { default as Television } from './television.js';
+export { default as TemperatureSensor } from './temperatureSensor.js';
+export { default as Thermostat } from './thermostat.js';
+export { default as VacuumCleaner } from './vacuumCleaner.js';
+export { default as Washer } from './washer.js';
+export { default as WaterHeater } from './waterHeater.js';
+export { default as Wearable } from './wearable.js';

--- a/lambda/alexa/smarthome/device/types/interiorBlind.js
+++ b/lambda/alexa/smarthome/device/types/interiorBlind.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Door = require('./door');
-const { PositionState, TiltAngle } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Door from './door.js';
+import { PositionState, TiltAngle } from '../attributes/index.js';
 
 /**
  * Defines interior blind device type class
  * @extends Door
  */
-class InteriorBlind extends Door {
+export default class InteriorBlind extends Door {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class InteriorBlind extends Door {
     return [AlexaDisplayCategory.INTERIOR_BLIND];
   }
 }
-
-module.exports = InteriorBlind;

--- a/lambda/alexa/smarthome/device/types/laptop.js
+++ b/lambda/alexa/smarthome/device/types/laptop.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const MobileDevice = require('./mobileDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import MobileDevice from './mobileDevice.js';
 
 /**
  * Defines laptop device type class
  * @extends MobileDevice
  */
-class Laptop extends MobileDevice {
+export default class Laptop extends MobileDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Laptop extends MobileDevice {
     return [AlexaDisplayCategory.LAPTOP];
   }
 }
-
-module.exports = Laptop;

--- a/lambda/alexa/smarthome/device/types/light.js
+++ b/lambda/alexa/smarthome/device/types/light.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { Brightness, Color, ColorTemperature, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { Brightness, Color, ColorTemperature, PowerState } from '../attributes/index.js';
 
 /**
  * Defines Light device type class
  * @extends GenericDevice
  */
-class Light extends GenericDevice {
+export default class Light extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Light extends GenericDevice {
     return [AlexaDisplayCategory.LIGHT];
   }
 }
-
-module.exports = Light;

--- a/lambda/alexa/smarthome/device/types/lock.js
+++ b/lambda/alexa/smarthome/device/types/lock.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const { LockState, CurrentLockState, BatteryLevel, genericAttributes } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import { LockState, CurrentLockState, BatteryLevel, genericAttributes } from '../attributes/index.js';
 
 /**
  * Defines lock device type class
  * @extends DeviceType
  */
-class Lock extends DeviceType {
+export default class Lock extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Lock extends DeviceType {
     return [AlexaDisplayCategory.SMARTLOCK];
   }
 }
-
-module.exports = Lock;

--- a/lambda/alexa/smarthome/device/types/microwave.js
+++ b/lambda/alexa/smarthome/device/types/microwave.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines microwave device type class
  * @extends GenericDevice
  */
-class Microwave extends GenericDevice {
+export default class Microwave extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Microwave extends GenericDevice {
     return [AlexaDisplayCategory.MICROWAVE];
   }
 }
-
-module.exports = Microwave;

--- a/lambda/alexa/smarthome/device/types/mobileDevice.js
+++ b/lambda/alexa/smarthome/device/types/mobileDevice.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const NetworkDevice = require('./networkDevice');
-const { BatteryLevel } = require('../attributes');
+import NetworkDevice from './networkDevice.js';
+import { BatteryLevel } from '../attributes/index.js';
 
 /**
  * Defines mobile device type class
  * @extends NetworkDevice
  */
-class MobileDevice extends NetworkDevice {
+export default class MobileDevice extends NetworkDevice {
   /**
    * Returns supported attributes
    * @return {Array}
@@ -27,5 +27,3 @@ class MobileDevice extends NetworkDevice {
     return [BatteryLevel, ...super.supportedAttributes];
   }
 }
-
-module.exports = MobileDevice;

--- a/lambda/alexa/smarthome/device/types/mobilePhone.js
+++ b/lambda/alexa/smarthome/device/types/mobilePhone.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const MobileDevice = require('./mobileDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import MobileDevice from './mobileDevice.js';
 
 /**
  * Defines mobile phone device type class
  * @extends MobileDevice
  */
-class MobilePhone extends MobileDevice {
+export default class MobilePhone extends MobileDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class MobilePhone extends MobileDevice {
     return [AlexaDisplayCategory.MOBILE_PHONE];
   }
 }
-
-module.exports = MobilePhone;

--- a/lambda/alexa/smarthome/device/types/motionSensor.js
+++ b/lambda/alexa/smarthome/device/types/motionSensor.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Sensor = require('./sensor');
-const { MotionDetectionState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Sensor from './sensor.js';
+import { MotionDetectionState } from '../attributes/index.js';
 
 /**
  * Defines motion sensor device type class
  * @extends Sensor
  */
-class MotionSensor extends Sensor {
+export default class MotionSensor extends Sensor {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class MotionSensor extends Sensor {
     return [AlexaDisplayCategory.MOTION_SENSOR];
   }
 }
-
-module.exports = MotionSensor;

--- a/lambda/alexa/smarthome/device/types/musicSystem.js
+++ b/lambda/alexa/smarthome/device/types/musicSystem.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const StreamingDevice = require('./streamingDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import StreamingDevice from './streamingDevice.js';
 
 /**
  * Defines music system device type class
  * @extends StreamingDevice
  */
-class MusicSystem extends StreamingDevice {
+export default class MusicSystem extends StreamingDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class MusicSystem extends StreamingDevice {
     return [AlexaDisplayCategory.MUSIC_SYSTEM];
   }
 }
-
-module.exports = MusicSystem;

--- a/lambda/alexa/smarthome/device/types/networkDevice.js
+++ b/lambda/alexa/smarthome/device/types/networkDevice.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Capability, Property } = require('@alexa/smarthome/constants');
-const GenericDevice = require('./genericDevice');
-const { NetworkAccess } = require('../attributes');
+import { Capability, Property } from '#alexa/smarthome/constants.js';
+import GenericDevice from './genericDevice.js';
+import { NetworkAccess } from '../attributes/index.js';
 
 /**
  * Defines network device type class
  * @extends GenericDevice
  */
-class NetworkDevice extends GenericDevice {
+export default class NetworkDevice extends GenericDevice {
   /**
    * Returns supported attributes
    * @return {Array}
@@ -36,5 +36,3 @@ class NetworkDevice extends GenericDevice {
     return [{ name: Capability.NETWORKING_CONNECTED_DEVICE, property: Property.CONNECTED_DEVICE }];
   }
 }
-
-module.exports = NetworkDevice;

--- a/lambda/alexa/smarthome/device/types/networkHardware.js
+++ b/lambda/alexa/smarthome/device/types/networkHardware.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const { Capability } = require('@alexa/smarthome/constants');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import { Capability } from '#alexa/smarthome/constants.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines network hardware device type class
  * @extends GenericDevice
  */
-class NetworkHardware extends GenericDevice {
+export default class NetworkHardware extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class NetworkHardware extends GenericDevice {
     return [AlexaDisplayCategory.NETWORK_HARDWARE];
   }
 }
-
-module.exports = NetworkHardware;

--- a/lambda/alexa/smarthome/device/types/other.js
+++ b/lambda/alexa/smarthome/device/types/other.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
 
 /**
  * Defines other device type class
  * @extends DeviceType
  */
-class Other extends DeviceType {
+export default class Other extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Other extends DeviceType {
     return [AlexaDisplayCategory.OTHER];
   }
 }
-
-module.exports = Other;

--- a/lambda/alexa/smarthome/device/types/outlet.js
+++ b/lambda/alexa/smarthome/device/types/outlet.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Switch = require('./switch');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Switch from './switch.js';
 
 /**
  * Defines outlet device type class
  * @extends Switch
  */
-class Outlet extends Switch {
+export default class Outlet extends Switch {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Outlet extends Switch {
     return [AlexaDisplayCategory.SMARTPLUG];
   }
 }
-
-module.exports = Outlet;

--- a/lambda/alexa/smarthome/device/types/oven.js
+++ b/lambda/alexa/smarthome/device/types/oven.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines oven device type class
  * @extends GenericDevice
  */
-class Oven extends GenericDevice {
+export default class Oven extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Oven extends GenericDevice {
     return [AlexaDisplayCategory.OVEN];
   }
 }
-
-module.exports = Oven;

--- a/lambda/alexa/smarthome/device/types/phone.js
+++ b/lambda/alexa/smarthome/device/types/phone.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines phone device type class
  * @extends GenericDevice
  */
-class Phone extends GenericDevice {
+export default class Phone extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Phone extends GenericDevice {
     return [AlexaDisplayCategory.PHONE];
   }
 }
-
-module.exports = Phone;

--- a/lambda/alexa/smarthome/device/types/printer.js
+++ b/lambda/alexa/smarthome/device/types/printer.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines printer device type class
  * @extends GenericDevice
  */
-class Printer extends GenericDevice {
+export default class Printer extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Printer extends GenericDevice {
     return [AlexaDisplayCategory.PRINTER];
   }
 }
-
-module.exports = Printer;

--- a/lambda/alexa/smarthome/device/types/router.js
+++ b/lambda/alexa/smarthome/device/types/router.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const NetworkHardware = require('./networkHardware');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import NetworkHardware from './networkHardware.js';
 
 /**
  * Defines router device type class
  * @extends NetworkHardware
  */
-class Router extends NetworkHardware {
+export default class Router extends NetworkHardware {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Router extends NetworkHardware {
     return [AlexaDisplayCategory.ROUTER];
   }
 }
-
-module.exports = Router;

--- a/lambda/alexa/smarthome/device/types/scene.js
+++ b/lambda/alexa/smarthome/device/types/scene.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const { Scene: SceneAttribute } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import { Scene as SceneAttribute } from '../attributes/index.js';
 
 /**
  * Defines scene device type class
  * @extends DeviceType
  */
-class Scene extends DeviceType {
+export default class Scene extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Scene extends DeviceType {
     return [AlexaDisplayCategory.SCENE_TRIGGER];
   }
 }
-
-module.exports = Scene;

--- a/lambda/alexa/smarthome/device/types/screen.js
+++ b/lambda/alexa/smarthome/device/types/screen.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Television = require('./television');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Television from './television.js';
 
 /**
  * Defines screne device type class
  * @extends Television
  */
-class Screen extends Television {
+export default class Screen extends Television {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Screen extends Television {
     return [AlexaDisplayCategory.SCREEN];
   }
 }
-
-module.exports = Screen;

--- a/lambda/alexa/smarthome/device/types/securityPanel.js
+++ b/lambda/alexa/smarthome/device/types/securityPanel.js
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const DeviceType = require('./type');
-const {
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import DeviceType from './type.js';
+import {
   ArmState,
   BurglaryAlarm,
   CarbonMonoxideAlarm,
@@ -24,13 +24,13 @@ const {
   TroubleAlert,
   ZonesAlert,
   genericAttributes
-} = require('../attributes');
+} from '../attributes/index.js';
 
 /**
  * Defines security panel device type class
  * @extends DeviceType
  */
-class SecurityPanel extends DeviceType {
+export default class SecurityPanel extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -74,5 +74,3 @@ class SecurityPanel extends DeviceType {
     return [AlexaDisplayCategory.SECURITY_PANEL];
   }
 }
-
-module.exports = SecurityPanel;

--- a/lambda/alexa/smarthome/device/types/securitySystem.js
+++ b/lambda/alexa/smarthome/device/types/securitySystem.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const SecurityPanel = require('./securityPanel');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import SecurityPanel from './securityPanel.js';
 
 /**
  * Defines security system device type class
  * @extends SecurityPanel
  */
-class SecuritySystem extends SecurityPanel {
+export default class SecuritySystem extends SecurityPanel {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class SecuritySystem extends SecurityPanel {
     return [AlexaDisplayCategory.SECURITY_SYSTEM];
   }
 }
-
-module.exports = SecuritySystem;

--- a/lambda/alexa/smarthome/device/types/sensor.js
+++ b/lambda/alexa/smarthome/device/types/sensor.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const DeviceType = require('./type');
-const { BatteryLevel, genericAttributes } = require('../attributes');
+import DeviceType from './type.js';
+import { BatteryLevel, genericAttributes } from '../attributes/index.js';
 
 /**
  * Defines sensor device type class
  * @extends DeviceType
  */
-class Sensor extends DeviceType {
+export default class Sensor extends DeviceType {
   /**
    * Returns supported attributes
    * @return {Array}
@@ -27,5 +27,3 @@ class Sensor extends DeviceType {
     return [BatteryLevel, ...genericAttributes];
   }
 }
-
-module.exports = Sensor;

--- a/lambda/alexa/smarthome/device/types/slowCooker.js
+++ b/lambda/alexa/smarthome/device/types/slowCooker.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines slow cooker device type class
  * @extends GenericDevice
  */
-class SlowCooker extends GenericDevice {
+export default class SlowCooker extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class SlowCooker extends GenericDevice {
     return [AlexaDisplayCategory.SLOW_COOKER];
   }
 }
-
-module.exports = SlowCooker;

--- a/lambda/alexa/smarthome/device/types/speaker.js
+++ b/lambda/alexa/smarthome/device/types/speaker.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Entertainment = require('./entertainment');
-const { VolumeLevel, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Entertainment from './entertainment.js';
+import { VolumeLevel, PowerState } from '../attributes/index.js';
 
 /**
  * Defines speaker device type class
  * @extends Entertainment
  */
-class Speaker extends Entertainment {
+export default class Speaker extends Entertainment {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class Speaker extends Entertainment {
     return [AlexaDisplayCategory.SPEAKER];
   }
 }
-
-module.exports = Speaker;

--- a/lambda/alexa/smarthome/device/types/streamingDevice.js
+++ b/lambda/alexa/smarthome/device/types/streamingDevice.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Entertainment = require('./entertainment');
-const { Playback, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Entertainment from './entertainment.js';
+import { Playback, PowerState } from '../attributes/index.js';
 
 /**
  * Defines streaming device type class
  * @extends Entertainment
  */
-class StreamingDevice extends Entertainment {
+export default class StreamingDevice extends Entertainment {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class StreamingDevice extends Entertainment {
     return [AlexaDisplayCategory.STREAMING_DEVICE];
   }
 }
-
-module.exports = StreamingDevice;

--- a/lambda/alexa/smarthome/device/types/switch.js
+++ b/lambda/alexa/smarthome/device/types/switch.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { Percentage, PowerLevel, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { Percentage, PowerLevel, PowerState } from '../attributes/index.js';
 
 /**
  * Defines switch device type class
  * @extends GenericDevice
  */
-class Switch extends GenericDevice {
+export default class Switch extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class Switch extends GenericDevice {
     return [AlexaDisplayCategory.SWITCH];
   }
 }
-
-module.exports = Switch;

--- a/lambda/alexa/smarthome/device/types/tablet.js
+++ b/lambda/alexa/smarthome/device/types/tablet.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const MobileDevice = require('./mobileDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import MobileDevice from './mobileDevice.js';
 
 /**
  * Defines tablet device type class
  * @extends MobileDevice
  */
-class Tablet extends MobileDevice {
+export default class Tablet extends MobileDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Tablet extends MobileDevice {
     return [AlexaDisplayCategory.TABLET];
   }
 }
-
-module.exports = Tablet;

--- a/lambda/alexa/smarthome/device/types/television.js
+++ b/lambda/alexa/smarthome/device/types/television.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Entertainment = require('./entertainment');
-const { Channel, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Entertainment from './entertainment.js';
+import { Channel, PowerState } from '../attributes/index.js';
 
 /**
  * Defines television device type class
  * @extends Entertainment
  */
-class Television extends Entertainment {
+export default class Television extends Entertainment {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class Television extends Entertainment {
     return [AlexaDisplayCategory.TV];
   }
 }
-
-module.exports = Television;

--- a/lambda/alexa/smarthome/device/types/temperatureSensor.js
+++ b/lambda/alexa/smarthome/device/types/temperatureSensor.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const Sensor = require('./sensor');
-const { Temperature } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import Sensor from './sensor.js';
+import { Temperature } from '../attributes/index.js';
 
 /**
  * Defines temperature sensor device type class
  * @extends Sensor
  */
-class TemperatureSensor extends Sensor {
+export default class TemperatureSensor extends Sensor {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class TemperatureSensor extends Sensor {
     return [AlexaDisplayCategory.TEMPERATURE_SENSOR];
   }
 }
-
-module.exports = TemperatureSensor;

--- a/lambda/alexa/smarthome/device/types/thermostat.js
+++ b/lambda/alexa/smarthome/device/types/thermostat.js
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const { Parameter } = require('@alexa/smarthome/metadata');
-const DeviceType = require('./type');
-const {
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import { Parameter } from '#alexa/smarthome/metadata.js';
+import DeviceType from './type.js';
+import {
   HeatingCoolingMode,
   TargetTemperature,
   CoolingSetpoint,
@@ -27,13 +27,13 @@ const {
   Humidity,
   BatteryLevel,
   genericAttributes
-} = require('../attributes');
+} from '../attributes/index.js';
 
 /**
  * Defines thermostat device type class
  * @extends DeviceType
  */
-class Thermostat extends DeviceType {
+export default class Thermostat extends DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -93,5 +93,3 @@ class Thermostat extends DeviceType {
     return super.getConfig(metadata);
   }
 }
-
-module.exports = Thermostat;

--- a/lambda/alexa/smarthome/device/types/type.js
+++ b/lambda/alexa/smarthome/device/types/type.js
@@ -14,7 +14,7 @@
 /**
  * Defines device type base class
  */
-class DeviceType {
+export default class DeviceType {
   /**
    * Returns supported names
    * @return {Array}
@@ -64,5 +64,3 @@ class DeviceType {
     return metadata.config;
   }
 }
-
-module.exports = DeviceType;

--- a/lambda/alexa/smarthome/device/types/vacuumCleaner.js
+++ b/lambda/alexa/smarthome/device/types/vacuumCleaner.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { VacuumMode, FanSpeed, BatteryLevel, PowerState } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { VacuumMode, FanSpeed, BatteryLevel, PowerState } from '../attributes/index.js';
 
 /**
  * Defines vacuum cleaner device type class
  * @extends GenericDevice
  */
-class VacuumCleaner extends GenericDevice {
+export default class VacuumCleaner extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -52,5 +52,3 @@ class VacuumCleaner extends GenericDevice {
     return [AlexaDisplayCategory.VACUUM_CLEANER];
   }
 }
-
-module.exports = VacuumCleaner;

--- a/lambda/alexa/smarthome/device/types/washer.js
+++ b/lambda/alexa/smarthome/device/types/washer.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
 
 /**
  * Defines washer device type class
  * @extends GenericDevice
  */
-class Washer extends GenericDevice {
+export default class Washer extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Washer extends GenericDevice {
     return [AlexaDisplayCategory.WASHER];
   }
 }
-
-module.exports = Washer;

--- a/lambda/alexa/smarthome/device/types/waterHeater.js
+++ b/lambda/alexa/smarthome/device/types/waterHeater.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const GenericDevice = require('./genericDevice');
-const { TargetTemperature, Temperature } = require('../attributes');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import GenericDevice from './genericDevice.js';
+import { TargetTemperature, Temperature } from '../attributes/index.js';
 
 /**
  * Defines water heater device type class
  * @extends GenericDevice
  */
-class WaterHeater extends GenericDevice {
+export default class WaterHeater extends GenericDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -44,5 +44,3 @@ class WaterHeater extends GenericDevice {
     return [AlexaDisplayCategory.WATER_HEATER];
   }
 }
-
-module.exports = WaterHeater;

--- a/lambda/alexa/smarthome/device/types/wearable.js
+++ b/lambda/alexa/smarthome/device/types/wearable.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaDisplayCategory = require('@alexa/smarthome/category');
-const MobileDevice = require('./type');
+import AlexaDisplayCategory from '#alexa/smarthome/category.js';
+import MobileDevice from './type.js';
 
 /**
  * Defines wearable device type class
  * @extends MobileDevice
  */
-class Wearable extends MobileDevice {
+export default class Wearable extends MobileDevice {
   /**
    * Returns supported names
    * @return {Array}
@@ -35,5 +35,3 @@ class Wearable extends MobileDevice {
     return [AlexaDisplayCategory.WEARABLE];
   }
 }
-
-module.exports = Wearable;

--- a/lambda/alexa/smarthome/directive.js
+++ b/lambda/alexa/smarthome/directive.js
@@ -11,15 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { decompressJSON } = require('@root/utils');
-const { Interface } = require('./constants');
-const AlexaEndpoint = require('./endpoint');
-const AlexaResponse = require('./response');
+import { decompressJSON } from '#root/utils.js';
+import { Interface } from './constants.js';
+import AlexaEndpoint from './endpoint.js';
+import * as AlexaHandlers from './handlers/index.js';
+import AlexaResponse from './response.js';
 
 /**
  * Defines alexa directive class
  */
-class AlexaDirective {
+export default class AlexaDirective {
   /**
    * Constructor
    * @param {Object} directive
@@ -85,6 +86,18 @@ class AlexaDirective {
   }
 
   /**
+   * Returns handler function
+   * @return {Function}
+   */
+  getHandler() {
+    for (const handler of Object.values(AlexaHandlers)) {
+      if (handler.namespace === this.namespace) {
+        return handler.directives[this.name];
+      }
+    }
+  }
+
+  /**
    * Loads endpoint
    */
   loadEndpoint() {
@@ -146,5 +159,3 @@ class AlexaDirective {
     };
   }
 }
-
-module.exports = AlexaDirective;

--- a/lambda/alexa/smarthome/errors.js
+++ b/lambda/alexa/smarthome/errors.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface } = require('./constants');
+import { Interface } from './constants.js';
 
 /**
  * Defines alexa error class
  *  https://developer.amazon.com/docs/device-apis/alexa-errorresponse.html
  * @extends Error
  */
-class AlexaError extends Error {
+export class AlexaError extends Error {
   /**
    * Constructor
    * @param {String} message
@@ -53,11 +53,11 @@ class AlexaError extends Error {
   }
 
   /**
-   * Returns new alexa error object based on generic error
+   * Returns new alexa error object based on error
    * @param  {Object} error
    * @return {Object}
    */
-  static fromGenericError(error) {
+  static from(error) {
     switch (error.name) {
       case 'RequestError':
       case 'StatusCodeError':
@@ -84,7 +84,7 @@ class AlexaError extends Error {
  * Defines bridge unreachable error class
  * @extends AlexaError
  */
-class BridgeUnreachableError extends AlexaError {
+export class BridgeUnreachableError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -98,7 +98,7 @@ class BridgeUnreachableError extends AlexaError {
  * Defines endpoint unreachable error class
  * @extends AlexaError
  */
-class EndpointUnreachableError extends AlexaError {
+export class EndpointUnreachableError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -112,7 +112,7 @@ class EndpointUnreachableError extends AlexaError {
  * Defines internal error class
  * @extends AlexaError
  */
-class InternalError extends AlexaError {
+export class InternalError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -126,7 +126,7 @@ class InternalError extends AlexaError {
  * Defines invalid authorization credential error class
  * @extends AlexaError
  */
-class InvalidAuthorizationCredentialError extends AlexaError {
+export class InvalidAuthorizationCredentialError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -140,7 +140,7 @@ class InvalidAuthorizationCredentialError extends AlexaError {
  * Defines invalid directive error class
  * @extends AlexaError
  */
-class InvalidDirectiveError extends AlexaError {
+export class InvalidDirectiveError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -154,7 +154,7 @@ class InvalidDirectiveError extends AlexaError {
  * Defines invalid value error class
  * @extends AlexaError
  */
-class InvalidValueError extends AlexaError {
+export class InvalidValueError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -168,7 +168,7 @@ class InvalidValueError extends AlexaError {
  * Defines invalid endpoint error class
  * @extends AlexaError
  */
-class InvalidEndpointError extends AlexaError {
+export class InvalidEndpointError extends AlexaError {
   /**
    * Returns error type
    * @return {String}
@@ -182,7 +182,7 @@ class InvalidEndpointError extends AlexaError {
  * Defines current mode not supported error class
  * @extends AlexaError
  */
-class CurrentModeNotSupportedError extends AlexaError {
+export class CurrentModeNotSupportedError extends AlexaError {
   /**
    * Constructor
    * @param {String} message
@@ -226,7 +226,7 @@ class CurrentModeNotSupportedError extends AlexaError {
  * Defines temperature out of range error class
  * @extends AlexaError
  */
-class TemperatureOutOfRangeError extends AlexaError {
+export class TemperatureOutOfRangeError extends AlexaError {
   /**
    * Constructor
    * @param {String} message
@@ -271,7 +271,7 @@ class TemperatureOutOfRangeError extends AlexaError {
  * Defines value out of range error class
  * @extends AlexaError
  */
-class ValueOutOfRangeError extends AlexaError {
+export class ValueOutOfRangeError extends AlexaError {
   /**
    * Constructor
    * @param {String} message
@@ -311,7 +311,7 @@ class ValueOutOfRangeError extends AlexaError {
  *  https://developer.amazon.com/docs/device-apis/alexa-authorization.html#acceptgrant-error-handling
  * @extends AlexaError
  */
-class AuthorizationAcceptGrantError extends AlexaError {
+export class AuthorizationAcceptGrantError extends AlexaError {
   /**
    * Returns error namespace
    * @return {String}
@@ -348,7 +348,7 @@ class SafetyError extends AlexaError {
  * Defines safety obstacle detected error class
  * @extends SafetyError
  */
-class SafetyObstacleDetectedError extends SafetyError {
+export class SafetyObstacleDetectedError extends SafetyError {
   /**
    * Returns error type
    * @return {String}
@@ -377,7 +377,7 @@ class SecurityPanelError extends AlexaError {
  * Defines security panel authorization required error class
  * @extends SecurityPanelError
  */
-class SecurityPanelAuthorizationRequiredError extends SecurityPanelError {
+export class SecurityPanelAuthorizationRequiredError extends SecurityPanelError {
   /**
    * Returns error type
    * @return {String}
@@ -391,7 +391,7 @@ class SecurityPanelAuthorizationRequiredError extends SecurityPanelError {
  * Defines security panel bypass needed error class
  * @extends SecurityPanelError
  */
-class SecurityPanelBypassNeededError extends SecurityPanelError {
+export class SecurityPanelBypassNeededError extends SecurityPanelError {
   /**
    * Constructor
    * @param {String} message
@@ -425,7 +425,7 @@ class SecurityPanelBypassNeededError extends SecurityPanelError {
  * Defines security panel not ready needed error class
  * @extends SecurityPanelError
  */
-class SecurityPanelNotReadyError extends SecurityPanelError {
+export class SecurityPanelNotReadyError extends SecurityPanelError {
   /**
    * Returns error type
    * @return {String}
@@ -439,7 +439,7 @@ class SecurityPanelNotReadyError extends SecurityPanelError {
  * Defines security panel unauthorized error class
  * @extends SecurityPanelError
  */
-class SecurityPanelUnauthorizedError extends SecurityPanelError {
+export class SecurityPanelUnauthorizedError extends SecurityPanelError {
   /**
    * Returns error type
    * @return {String}
@@ -453,7 +453,7 @@ class SecurityPanelUnauthorizedError extends SecurityPanelError {
  * Defines security panel uncleared alarm error class
  * @extends SecurityPanelError
  */
-class SecurityPanelUnclearedAlarmError extends SecurityPanelError {
+export class SecurityPanelUnclearedAlarmError extends SecurityPanelError {
   /**
    * Returns error type
    * @return {String}
@@ -467,7 +467,7 @@ class SecurityPanelUnclearedAlarmError extends SecurityPanelError {
  * Defines security panel uncleared trouble error class
  * @extends SecurityPanelError
  */
-class SecurityPanelUnclearedTroubleError extends SecurityPanelError {
+export class SecurityPanelUnclearedTroubleError extends SecurityPanelError {
   /**
    * Returns error type
    * @return {String}
@@ -496,7 +496,7 @@ class ThermostatError extends AlexaError {
  * Defines thermostat off error class
  * @extends ThermostatError
  */
-class ThermostatOffError extends ThermostatError {
+export class ThermostatOffError extends ThermostatError {
   /**
    * Returns error type
    * @return {String}
@@ -510,7 +510,7 @@ class ThermostatOffError extends ThermostatError {
  * Defines thermostat mode unsupported error class
  * @extends ThermostatError
  */
-class ThermostatModeUnsupportedError extends ThermostatError {
+export class ThermostatModeUnsupportedError extends ThermostatError {
   /**
    * Returns error type
    * @return {String}
@@ -524,7 +524,7 @@ class ThermostatModeUnsupportedError extends ThermostatError {
  * Defines thermostat dual/triple setpoints unsupported error class
  * @extends ThermostatError
  */
-class ThermostatSetpointsUnsupportedError extends ThermostatError {
+export class ThermostatSetpointsUnsupportedError extends ThermostatError {
   /**
    * Constructor
    * @param {String} message
@@ -547,7 +547,7 @@ class ThermostatSetpointsUnsupportedError extends ThermostatError {
  * Defines thermostat setpoints too close error class
  * @extends ThermostatError
  */
-class ThermostatSetpointsTooCloseError extends ThermostatError {
+export class ThermostatSetpointsTooCloseError extends ThermostatError {
   /**
    * Constructor
    * @param {String} message
@@ -586,7 +586,7 @@ class ThermostatSetpointsTooCloseError extends ThermostatError {
  * Defines thermostat schedule request error class
  * @extends ThermostatError
  */
-class ThermostatScheduleRequestError extends ThermostatError {
+export class ThermostatScheduleRequestError extends ThermostatError {
   /**
    * Returns error type
    * @return {String}
@@ -595,30 +595,3 @@ class ThermostatScheduleRequestError extends ThermostatError {
     return 'UNWILLING_TO_SET_SCHEDULE';
   }
 }
-
-module.exports = {
-  AlexaError,
-  BridgeUnreachableError,
-  EndpointUnreachableError,
-  InternalError,
-  InvalidAuthorizationCredentialError,
-  InvalidDirectiveError,
-  InvalidValueError,
-  InvalidEndpointError,
-  CurrentModeNotSupportedError,
-  TemperatureOutOfRangeError,
-  ValueOutOfRangeError,
-  AuthorizationAcceptGrantError,
-  SafetyObstacleDetectedError,
-  SecurityPanelAuthorizationRequiredError,
-  SecurityPanelBypassNeededError,
-  SecurityPanelNotReadyError,
-  SecurityPanelUnauthorizedError,
-  SecurityPanelUnclearedAlarmError,
-  SecurityPanelUnclearedTroubleError,
-  ThermostatOffError,
-  ThermostatModeUnsupportedError,
-  ThermostatSetpointsUnsupportedError,
-  ThermostatSetpointsTooCloseError,
-  ThermostatScheduleRequestError
-};

--- a/lambda/alexa/smarthome/handlers/alexa.js
+++ b/lambda/alexa/smarthome/handlers/alexa.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface } = require('../constants');
-const AlexaHandler = require('./handler');
+import { Interface } from '../constants.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines alexa state reporting cause type enum
  *  https://developer.amazon.com/docs/smarthome/state-reporting-for-a-smart-home-skill.html#cause-object
  * @type {Object}
  */
-const CauseType = Object.freeze({
+export const CauseType = Object.freeze({
   APP_INTERACTION: 'APP_INTERACTION',
   PERIODIC_POLL: 'PERIODIC_POLL',
   PHYSICAL_INTERACTION: 'PHYSICAL_INTERACTION',
@@ -31,7 +31,7 @@ const CauseType = Object.freeze({
  * Defines Alexa interface handler class
  * @extends AlexaHandler
  */
-class Alexa extends AlexaHandler {
+export default class Alexa extends AlexaHandler {
   /**
    * Defines report state directive
    * @type {String}
@@ -71,6 +71,3 @@ class Alexa extends AlexaHandler {
     return directive.response({ name: Alexa.STATE_REPORT });
   }
 }
-
-module.exports = Alexa;
-module.exports.CauseType = CauseType;

--- a/lambda/alexa/smarthome/handlers/authorization.js
+++ b/lambda/alexa/smarthome/handlers/authorization.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface } = require('../constants');
-const { AuthorizationAcceptGrantError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { Interface } from '../constants.js';
+import { AuthorizationAcceptGrantError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.Authorization interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-authorization.html#directives
  * @extends AlexaHandler
  */
-class Authorization extends AlexaHandler {
+export default class Authorization extends AlexaHandler {
   /**
    * Defines accept grant directive
    * @type {String}
@@ -54,5 +54,3 @@ class Authorization extends AlexaHandler {
     throw new AuthorizationAcceptGrantError('Not supported');
   }
 }
-
-module.exports = Authorization;

--- a/lambda/alexa/smarthome/handlers/brightnessController.js
+++ b/lambda/alexa/smarthome/handlers/brightnessController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.BrightnessController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-brightnesscontroller.html#directives
  * @extends AlexaHandler
  */
-class BrightnessController extends AlexaHandler {
+export default class BrightnessController extends AlexaHandler {
   /**
    * Defines set brightness directive
    * @type {String}
@@ -108,5 +108,3 @@ class BrightnessController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = BrightnessController;

--- a/lambda/alexa/smarthome/handlers/cameraStreamController.js
+++ b/lambda/alexa/smarthome/handlers/cameraStreamController.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { parseUrl } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { CurrentModeNotSupportedError } = require('../errors');
-const { CameraStream } = require('../properties');
-const AlexaHandler = require('./handler');
+import { parseUrl } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { CurrentModeNotSupportedError } from '../errors.js';
+import { AuthType } from '../properties/cameraStream.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.CameraStreamController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-camerastreamcontroller.html#directives
  * @extends AlexaHandler
  */
-class CameraStreamController extends AlexaHandler {
+export default class CameraStreamController extends AlexaHandler {
   /**
    * Defines initialize camera streams directive
    * @type {String}
@@ -68,7 +68,7 @@ class CameraStreamController extends AlexaHandler {
     }
 
     // Add basic auth credentials to camera stream url if necessary
-    if (authorizationType === CameraStream.AuthType.BASIC) {
+    if (authorizationType === AuthType.BASIC) {
       streamUrl.username = username;
       streamUrl.password = password;
     }
@@ -92,5 +92,3 @@ class CameraStreamController extends AlexaHandler {
     });
   }
 }
-
-module.exports = CameraStreamController;

--- a/lambda/alexa/smarthome/handlers/channelController.js
+++ b/lambda/alexa/smarthome/handlers/channelController.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { ItemType } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError, ValueOutOfRangeError } = require('../errors');
-const { ChannelStep } = require('../properties');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { ItemType } from '#openhab/constants.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError, ValueOutOfRangeError } from '../errors.js';
+import { ChannelStep } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.ChannelController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-channelcontroller.html#directives
  * @extends AlexaHandler
  */
-class ChannelController extends AlexaHandler {
+export default class ChannelController extends AlexaHandler {
   /**
    * Defines change channel directive
    * @type {String}
@@ -168,5 +168,3 @@ class ChannelController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ChannelController;

--- a/lambda/alexa/smarthome/handlers/colorController.js
+++ b/lambda/alexa/smarthome/handlers/colorController.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.ColorController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-colorcontroller.html#directives
  * @extends AlexaHandler
  */
-class ColorController extends AlexaHandler {
+export default class ColorController extends AlexaHandler {
   /**
    * Defines set color directive
    * @type {String}
@@ -79,5 +79,3 @@ class ColorController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ColorController;

--- a/lambda/alexa/smarthome/handlers/colorTemperatureController.js
+++ b/lambda/alexa/smarthome/handlers/colorTemperatureController.js
@@ -11,23 +11,23 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const {
+import { clamp } from '#root/utils.js';
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Interface, Property } from '../constants.js';
+import {
   CurrentModeNotSupportedError,
   EndpointUnreachableError,
   InvalidValueError,
   ValueOutOfRangeError
-} = require('../errors');
-const AlexaHandler = require('./handler');
+} from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.ColorTemperatureController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-colortemperaturecontroller.html#directives
  * @extends AlexaHandler
  */
-class ColorTemperatureController extends AlexaHandler {
+export default class ColorTemperatureController extends AlexaHandler {
   /**
    * Defines set color temperature directive
    * @type {String}
@@ -154,5 +154,3 @@ class ColorTemperatureController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ColorTemperatureController;

--- a/lambda/alexa/smarthome/handlers/discovery.js
+++ b/lambda/alexa/smarthome/handlers/discovery.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const log = require('@root/log');
-const { ItemType } = require('@openhab/constants');
-const { Interface } = require('../constants');
-const AlexaEndpoint = require('../endpoint');
-const AlexaHandler = require('./handler');
+import log from '#root/log.js';
+import { ItemType } from '#openhab/constants.js';
+import { Interface } from '../constants.js';
+import AlexaEndpoint from '../endpoint.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.Discovery interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-discovery.html#directives
  * @extends AlexaHandler
  */
-class Discovery extends AlexaHandler {
+export default class Discovery extends AlexaHandler {
   /**
    * Defines alexa discovery endpoints limit
    *  https://developer.amazon.com/docs/device-apis/alexa-discovery.html#limits
@@ -117,5 +117,3 @@ class Discovery extends AlexaHandler {
     });
   }
 }
-
-module.exports = Discovery;

--- a/lambda/alexa/smarthome/handlers/equalizerController.js
+++ b/lambda/alexa/smarthome/handlers/equalizerController.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.EqualizerController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-equalizercontroller.html#directives
  * @extends AlexaHandler
  */
-class EqualizerController extends AlexaHandler {
+export default class EqualizerController extends AlexaHandler {
   /**
    * Defines set bands directive
    * @type {String}
@@ -79,6 +79,12 @@ class EqualizerController extends AlexaHandler {
       interface: directive.namespace,
       property: Property.EQUALIZER_BANDS
     });
+
+    // Throw invalid value error if no equalizer bands properties defined
+    if (typeof properties === 'undefined') {
+      throw new InvalidValueError('No equalizer bands properties defined.');
+    }
+
     const commands = [];
 
     for (const { component, item, defaultLevel } of properties) {
@@ -106,6 +112,12 @@ class EqualizerController extends AlexaHandler {
       interface: directive.namespace,
       property: Property.EQUALIZER_BANDS
     });
+
+    // Throw invalid value error if no equalizer bands properties defined
+    if (typeof properties === 'undefined') {
+      throw new InvalidValueError('No equalizer bands properties defined.');
+    }
+
     const commands = [];
 
     for (const { component, item, increment, range, isRetrievable } of properties) {
@@ -162,6 +174,12 @@ class EqualizerController extends AlexaHandler {
       interface: directive.namespace,
       property: Property.EQUALIZER_MODE
     });
+
+    // Throw invalid value error if no equalizer mode property defined
+    if (typeof property === 'undefined') {
+      throw new InvalidValueError('No equalizer mode property defined.');
+    }
+
     const { item, supportedModes } = property;
     const mode = directive.payload.mode;
 
@@ -177,5 +195,3 @@ class EqualizerController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = EqualizerController;

--- a/lambda/alexa/smarthome/handlers/handler.js
+++ b/lambda/alexa/smarthome/handlers/handler.js
@@ -14,7 +14,7 @@
 /**
  * Defines alexa handler base class
  */
-class AlexaHandler {
+export default class AlexaHandler {
   /**
    * Defines handler namespace
    * @return {String}
@@ -31,5 +31,3 @@ class AlexaHandler {
     return {};
   }
 }
-
-module.exports = AlexaHandler;

--- a/lambda/alexa/smarthome/handlers/index.js
+++ b/lambda/alexa/smarthome/handlers/index.js
@@ -12,47 +12,30 @@
  */
 
 /**
- * Defines supported handler classes
- * @type {Object}
+ * Exports supported handler classes
  */
-module.exports = {
-  Alexa: require('./alexa'),
-  Authorization: require('./authorization'),
-  BrightnessController: require('./brightnessController'),
-  CameraStreamController: require('./cameraStreamController'),
-  ChannelController: require('./channelController'),
-  ColorController: require('./colorController'),
-  ColorTemperatureController: require('./colorTemperatureController'),
-  Discovery: require('./discovery'),
-  EqualizerController: require('./equalizerController'),
-  InputController: require('./inputController'),
-  LockController: require('./lockController'),
-  ModeController: require('./modeController'),
-  NetworkingAccessController: require('./networkingAccessController'),
-  PercentageController: require('./percentageController'),
-  PlaybackController: require('./playbackController'),
-  PowerController: require('./powerController'),
-  PowerLevelController: require('./powerLevelController'),
-  RangeController: require('./rangeController'),
-  Safety: require('./safety'),
-  SceneController: require('./sceneController'),
-  SecurityPanelController: require('./securityPanelController'),
-  Speaker: require('./speaker'),
-  StepSpeaker: require('./stepSpeaker'),
-  ThermostatController: require('./thermostatController'),
-  ToggleController: require('./toggleController')
-};
-
-/**
- * Returns handler function for a given directive namespace and name
- * @param  {String} namespace
- * @param  {String} name
- * @return {AsyncFunction}
- */
-module.exports.get = function (namespace, name) {
-  for (const handler of Object.values(this)) {
-    if (handler.namespace === namespace) {
-      return handler.directives[name];
-    }
-  }
-};
+export { default as Alexa } from './alexa.js';
+export { default as Authorization } from './authorization.js';
+export { default as BrightnessController } from './brightnessController.js';
+export { default as CameraStreamController } from './cameraStreamController.js';
+export { default as ChannelController } from './channelController.js';
+export { default as ColorController } from './colorController.js';
+export { default as ColorTemperatureController } from './colorTemperatureController.js';
+export { default as Discovery } from './discovery.js';
+export { default as EqualizerController } from './equalizerController.js';
+export { default as InputController } from './inputController.js';
+export { default as LockController } from './lockController.js';
+export { default as ModeController } from './modeController.js';
+export { default as NetworkingAccessController } from './networkingAccessController.js';
+export { default as PercentageController } from './percentageController.js';
+export { default as PlaybackController } from './playbackController.js';
+export { default as PowerController } from './powerController.js';
+export { default as PowerLevelController } from './powerLevelController.js';
+export { default as RangeController } from './rangeController.js';
+export { default as Safety } from './safety.js';
+export { default as SceneController } from './sceneController.js';
+export { default as SecurityPanelController } from './securityPanelController.js';
+export { default as Speaker } from './speaker.js';
+export { default as StepSpeaker } from './stepSpeaker.js';
+export { default as ThermostatController } from './thermostatController.js';
+export { default as ToggleController } from './toggleController.js';

--- a/lambda/alexa/smarthome/handlers/inputController.js
+++ b/lambda/alexa/smarthome/handlers/inputController.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const { InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import { InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.InputController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-inputcontroller.html#directives
  * @extends AlexaHandler
  */
-class InputController extends AlexaHandler {
+export default class InputController extends AlexaHandler {
   /**
    * Defines select input directive
    * @type {String}
@@ -71,5 +71,3 @@ class InputController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = InputController;

--- a/lambda/alexa/smarthome/handlers/lockController.js
+++ b/lambda/alexa/smarthome/handlers/lockController.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemValue } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const AlexaHandler = require('./handler');
+import { ItemValue } from '#openhab/constants.js';
+import { Interface, Property } from '../constants.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.LockController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-lockcontroller.html#directives
  * @extends AlexaHandler
  */
-class LockController extends AlexaHandler {
+export default class LockController extends AlexaHandler {
   /**
    * Defines lock directive
    * @type {String}
@@ -70,5 +70,3 @@ class LockController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = LockController;

--- a/lambda/alexa/smarthome/handlers/modeController.js
+++ b/lambda/alexa/smarthome/handlers/modeController.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const { OpenState } = require('../device/attributes');
-const { InvalidValueError, ValueOutOfRangeError } = require('../errors');
-const AlexaHandler = require('./handler');
-const Safety = require('./safety');
+import { Interface, Property } from '../constants.js';
+import { OpenState } from '../device/attributes/index.js';
+import { InvalidValueError, ValueOutOfRangeError } from '../errors.js';
+import AlexaHandler from './handler.js';
+import Safety from './safety.js';
 
 /**
  * Defines Alexa.ModeController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-modecontroller.html#directives
  * @extends AlexaHandler
  */
-class ModeController extends AlexaHandler {
+export default class ModeController extends AlexaHandler {
   /**
    * Defines set mode directive
    * @type {String}
@@ -144,5 +144,3 @@ class ModeController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ModeController;

--- a/lambda/alexa/smarthome/handlers/networkingAccessController.js
+++ b/lambda/alexa/smarthome/handlers/networkingAccessController.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.Networking.AccessController interface handler class
  *  https://developer.amazon.com/docs/networking/alexa-networking-accesscontroller.html#directives
  * @extends AlexaHandler
  */
-class NetworkingAccessController extends AlexaHandler {
+export default class NetworkingAccessController extends AlexaHandler {
   /**
    * Defines set network access directive
    * @type {String}
@@ -62,5 +62,3 @@ class NetworkingAccessController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = NetworkingAccessController;

--- a/lambda/alexa/smarthome/handlers/percentageController.js
+++ b/lambda/alexa/smarthome/handlers/percentageController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.PercentageController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-percentagecontroller.html#directives
  * @extends AlexaHandler
  */
-class PercentageController extends AlexaHandler {
+export default class PercentageController extends AlexaHandler {
   /**
    * Defines set percentage directive
    * @type {String}
@@ -109,5 +109,3 @@ class PercentageController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = PercentageController;

--- a/lambda/alexa/smarthome/handlers/playbackController.js
+++ b/lambda/alexa/smarthome/handlers/playbackController.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface } = require('../constants');
-const { InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { Interface } from '../constants.js';
+import { InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.PlaybackController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-playbackcontroller.html#directives
  * @extends AlexaHandler
  */
-class PlaybackController extends AlexaHandler {
+export default class PlaybackController extends AlexaHandler {
   /**
    * Defines fast forward directive
    * @type {String}
@@ -124,5 +124,3 @@ class PlaybackController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = PlaybackController;

--- a/lambda/alexa/smarthome/handlers/powerController.js
+++ b/lambda/alexa/smarthome/handlers/powerController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const { InvalidValueError } = require('../errors');
-const { PowerState } = require('../properties');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import { InvalidValueError } from '../errors.js';
+import { PowerState } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.PowerController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-powercontroller.html#directives
  * @extends AlexaHandler
  */
-class PowerController extends AlexaHandler {
+export default class PowerController extends AlexaHandler {
   /**
    * Defines turn on directive
    * @type {String}
@@ -77,5 +77,3 @@ class PowerController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = PowerController;

--- a/lambda/alexa/smarthome/handlers/powerLevelController.js
+++ b/lambda/alexa/smarthome/handlers/powerLevelController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.PowerLevelController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-powerlevelcontroller.html#directives
  * @extends AlexaHandler
  */
-class PowerLevelController extends AlexaHandler {
+export default class PowerLevelController extends AlexaHandler {
   /**
    * Defines set power level directive
    * @type {String}
@@ -103,5 +103,3 @@ class PowerLevelController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = PowerLevelController;

--- a/lambda/alexa/smarthome/handlers/rangeController.js
+++ b/lambda/alexa/smarthome/handlers/rangeController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.RangeController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-rangecontroller.html#directives
  * @extends AlexaHandler
  */
-class RangeController extends AlexaHandler {
+export default class RangeController extends AlexaHandler {
   /**
    * Defines set range value directive
    * @type {String}
@@ -124,5 +124,3 @@ class RangeController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = RangeController;

--- a/lambda/alexa/smarthome/handlers/safety.js
+++ b/lambda/alexa/smarthome/handlers/safety.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const { SafetyObstacleDetectedError } = require('../errors');
-const { AlertState } = require('../properties');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import { SafetyObstacleDetectedError } from '../errors.js';
+import { AlertState } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.Safety interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-safety-errorresponse.html
  * @extends AlexaHandler
  */
-class Safety extends AlexaHandler {
+export default class Safety extends AlexaHandler {
   /**
    * Defines handler namespace
    * @return {String}
@@ -54,13 +54,9 @@ class Safety extends AlexaHandler {
       });
 
     // Throw relevant safety error based on alert name found
-    if (alert) {
-      switch (alert.name) {
-        case Property.OBSTACLE_ALERT:
-          throw new SafetyObstacleDetectedError('Unable to close door because an obstacle is detected.');
-      }
+    switch (alert?.name) {
+      case Property.OBSTACLE_ALERT:
+        throw new SafetyObstacleDetectedError('Unable to close door because an obstacle is detected.');
     }
   }
 }
-
-module.exports = Safety;

--- a/lambda/alexa/smarthome/handlers/sceneController.js
+++ b/lambda/alexa/smarthome/handlers/sceneController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemValue } = require('@openhab/constants');
-const { Interface, Property } = require('../constants');
-const { CauseType } = require('./alexa');
-const AlexaHandler = require('./handler');
+import { ItemValue } from '#openhab/constants.js';
+import { Interface, Property } from '../constants.js';
+import { CauseType } from './alexa.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.SceneController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-scenecontroller.html#directives
  * @extends AlexaHandler
  */
-class SceneController extends AlexaHandler {
+export default class SceneController extends AlexaHandler {
   /**
    * Defines activate directive
    * @type {String}
@@ -90,5 +90,3 @@ class SceneController extends AlexaHandler {
     });
   }
 }
-
-module.exports = SceneController;

--- a/lambda/alexa/smarthome/handlers/securityPanelController.js
+++ b/lambda/alexa/smarthome/handlers/securityPanelController.js
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const {
+import { Interface, Property } from '../constants.js';
+import {
   InvalidValueError,
   SecurityPanelAuthorizationRequiredError,
   SecurityPanelBypassNeededError,
@@ -20,16 +20,17 @@ const {
   SecurityPanelUnauthorizedError,
   SecurityPanelUnclearedAlarmError,
   SecurityPanelUnclearedTroubleError
-} = require('../errors');
-const { ArmState, AlertState } = require('../properties');
-const AlexaHandler = require('./handler');
+} from '../errors.js';
+import { ArmState, AlertState } from '../properties/index.js';
+import { AuthType } from '../properties/armState.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.SecurityPanelController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-securitypanelcontroller.html#directives
  * @extends AlexaHandler
  */
-class SecurityPanelController extends AlexaHandler {
+export default class SecurityPanelController extends AlexaHandler {
   /**
    * Defines arm directive
    * @type {String}
@@ -106,26 +107,24 @@ class SecurityPanelController extends AlexaHandler {
       });
 
     // Throw relevant security panel error based on alert name found
-    if (alert) {
-      // prettier-ignore
-      switch (alert.name) {
-        case Property.ZONES_ALERT:
-          throw new SecurityPanelBypassNeededError(
-            'Unable to arm the security panel because it has open zones that must be bypassed.'
-          );
-        case Property.READY_ALERT:
-          throw new SecurityPanelNotReadyError(
-            'Unable to arm the security panel because it is not ready.'
-          );
-        case Property.ALARM_ALERT:
-          throw new SecurityPanelUnclearedAlarmError(
-            'Unable to arm the security panel because it is in alarm status.'
-          );
-        case Property.TROUBLE_ALERT:
-          throw new SecurityPanelUnclearedTroubleError(
-            'Unable to arm the security panel because it is in trouble status.'
-          );
-      }
+    // prettier-ignore
+    switch (alert?.name) {
+      case Property.ZONES_ALERT:
+        throw new SecurityPanelBypassNeededError(
+          'Unable to arm the security panel because it has open zones that must be bypassed.'
+        );
+      case Property.READY_ALERT:
+        throw new SecurityPanelNotReadyError(
+          'Unable to arm the security panel because it is not ready.'
+        );
+      case Property.ALARM_ALERT:
+        throw new SecurityPanelUnclearedAlarmError(
+          'Unable to arm the security panel because it is in alarm status.'
+        );
+      case Property.TROUBLE_ALERT:
+        throw new SecurityPanelUnclearedTroubleError(
+          'Unable to arm the security panel because it is in trouble status.'
+        );
     }
 
     // Get current arm alexa state
@@ -175,7 +174,7 @@ class SecurityPanelController extends AlexaHandler {
     const authorization = directive.payload.authorization;
 
     // Throw unauthorized error when provided pin code not valid
-    if (authorization?.type === ArmState.AuthType.FOUR_DIGIT_PIN && !pinCodes.includes(authorization.value)) {
+    if (authorization?.type === AuthType.FOUR_DIGIT_PIN && !pinCodes.includes(authorization.value)) {
       throw new SecurityPanelUnauthorizedError(
         'Unable to disarm the security panel because the PIN code is not correct.'
       );
@@ -201,5 +200,3 @@ class SecurityPanelController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = SecurityPanelController;

--- a/lambda/alexa/smarthome/handlers/speaker.js
+++ b/lambda/alexa/smarthome/handlers/speaker.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { EndpointUnreachableError, InvalidValueError } = require('../errors');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { EndpointUnreachableError, InvalidValueError } from '../errors.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.Speaker interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-speaker.html#directives
  * @extends AlexaHandler
  */
-class Speaker extends AlexaHandler {
+export default class Speaker extends AlexaHandler {
   /**
    * Defines set volume directive
    * @type {String}
@@ -152,5 +152,3 @@ class Speaker extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = Speaker;

--- a/lambda/alexa/smarthome/handlers/stepSpeaker.js
+++ b/lambda/alexa/smarthome/handlers/stepSpeaker.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const { InvalidValueError } = require('../errors');
-const { VolumeStep, MuteStep } = require('../properties');
-const AlexaHandler = require('./handler');
+import { clamp } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import { InvalidValueError } from '../errors.js';
+import { VolumeStep, MuteStep } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.StepSpeaker interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-stepspeaker.html#directives
  * @extends AlexaHandler
  */
-class StepSpeaker extends AlexaHandler {
+export default class StepSpeaker extends AlexaHandler {
   /**
    * Defines volume steps limit per request
    * @type {Number}
@@ -120,5 +120,3 @@ class StepSpeaker extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = StepSpeaker;

--- a/lambda/alexa/smarthome/handlers/thermostatController.js
+++ b/lambda/alexa/smarthome/handlers/thermostatController.js
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp, decamelize } = require('@root/utils');
-const { Interface, Property } = require('../constants');
-const {
+import { clamp, decamelize } from '#root/utils.js';
+import { Interface, Property } from '../constants.js';
+import {
   EndpointUnreachableError,
   InvalidValueError,
   TemperatureOutOfRangeError,
@@ -22,16 +22,16 @@ const {
   ThermostatScheduleRequestError,
   ThermostatSetpointsTooCloseError,
   ThermostatSetpointsUnsupportedError
-} = require('../errors');
-const { ThermostatMode, ThermostatHold } = require('../properties');
-const AlexaHandler = require('./handler');
+} from '../errors.js';
+import { ThermostatMode, ThermostatHold } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.ThermostatController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-thermostatcontroller.html#directives
  * @extends AlexaHandler
  */
-class ThermostatController extends AlexaHandler {
+export default class ThermostatController extends AlexaHandler {
   /**
    * Defines set target temperature directive
    * @type {String}
@@ -351,5 +351,3 @@ class ThermostatController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ThermostatController;

--- a/lambda/alexa/smarthome/handlers/toggleController.js
+++ b/lambda/alexa/smarthome/handlers/toggleController.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Interface, Property } = require('../constants');
-const { InvalidValueError } = require('../errors');
-const { ToggleState } = require('../properties');
-const AlexaHandler = require('./handler');
+import { Interface, Property } from '../constants.js';
+import { InvalidValueError } from '../errors.js';
+import { ToggleState } from '../properties/index.js';
+import AlexaHandler from './handler.js';
 
 /**
  * Defines Alexa.ToggleController interface handler class
  *  https://developer.amazon.com/docs/device-apis/alexa-togglecontroller.html#directives
  * @extends AlexaHandler
  */
-class ToggleController extends AlexaHandler {
+export default class ToggleController extends AlexaHandler {
   /**
    * Defines turn on directive
    * @type {String}
@@ -78,5 +78,3 @@ class ToggleController extends AlexaHandler {
     return directive.response();
   }
 }
-
-module.exports = ToggleController;

--- a/lambda/alexa/smarthome/index.js
+++ b/lambda/alexa/smarthome/index.js
@@ -11,20 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const config = require('@root/config');
-const log = require('@root/log');
-const OpenHAB = require('@openhab');
-const AlexaDirective = require('./directive');
-const AlexaHandlers = require('./handlers');
-const AlexaResponse = require('./response');
-const { AlexaError, InvalidDirectiveError } = require('./errors');
+import config from '#root/config.js';
+import log from '#root/log.js';
+import OpenHAB from '#openhab/index.js';
+import AlexaDirective from './directive.js';
+import AlexaResponse from './response.js';
+import { AlexaError, InvalidDirectiveError } from './errors.js';
 
 /**
- * Defines alexa smart home skill request handler
+ * Handles alexa smart home skill request
  * @param  {Object}  request
  * @return {Promise}
  */
-exports.handleRequest = async (request) => {
+export const handleRequest = async (request) => {
   // Initialize directive object
   const directive = new AlexaDirective(request.directive);
   // Initialize openhab object
@@ -34,7 +33,7 @@ exports.handleRequest = async (request) => {
 
   try {
     // Get directive handler function
-    const handler = AlexaHandlers.get(directive.namespace, directive.name);
+    const handler = directive.getHandler();
 
     // Throw invalid directive error if handler function not defined
     if (typeof handler !== 'function') {
@@ -61,7 +60,7 @@ exports.handleRequest = async (request) => {
     }
 
     // Get alexa error response
-    response = directive.error(error instanceof AlexaError ? error : AlexaError.fromGenericError(error));
+    response = directive.error(error instanceof AlexaError ? error : AlexaError.from(error));
   }
 
   // Log response object
@@ -72,10 +71,10 @@ exports.handleRequest = async (request) => {
 
 /**
  * Logs error based on error type
- * @param  {Object} error
- * @param  {Object} directive
+ * @param {Object} error
+ * @param {Object} directive
  */
-function logError(error, directive) {
+const logError = (error, directive) => {
   let level, message;
 
   // Define log level channel and error message based on error type
@@ -94,4 +93,4 @@ function logError(error, directive) {
   log.debug('Error:', error);
   // Log error message in defined log level channel with directive object essential properties
   log[level](message, { directive: directive.toJSON() });
-}
+};

--- a/lambda/alexa/smarthome/metadata.js
+++ b/lambda/alexa/smarthome/metadata.js
@@ -15,7 +15,7 @@
  * Defines alexa metadata parameter enum
  * @type {Object}
  */
-const Parameter = Object.freeze({
+export const Parameter = Object.freeze({
   ACTION_MAPPINGS: 'actionMappings',
   BINDING: 'binding',
   CAPABILITY_NAMES: 'capabilityNames',
@@ -63,7 +63,7 @@ const Parameter = Object.freeze({
  * Defines alexa metadata parameter type enum
  * @type {Object}
  */
-const ParameterType = Object.freeze({
+export const ParameterType = Object.freeze({
   BOOLEAN: 'boolean',
   FLOAT: 'float',
   INTEGER: 'integer',
@@ -76,7 +76,7 @@ const ParameterType = Object.freeze({
 /**
  * Defines alexa metadata class
  */
-class AlexaMetadata {
+export default class AlexaMetadata {
   /**
    * Defines alexa capability namespace format pattern
    * @type {RegExp}
@@ -155,7 +155,7 @@ class AlexaMetadata {
   }
 
   /**
-   * Returns converted value for a given type
+   * Returns converted value for a given parameter type
    * @param  {*}      value
    * @param  {String} type
    * @return {*}
@@ -164,43 +164,39 @@ class AlexaMetadata {
     const current = Array.isArray(value) ? 'array' : typeof value;
     const conversion = current + '->' + type;
 
-    try {
-      switch (conversion) {
-        case `number->${ParameterType.BOOLEAN}`:
-        case `string->${ParameterType.BOOLEAN}`:
-          return ['0', 'false', 'no'].includes(value.toString().toLowerCase()) === false;
-        case `number->${ParameterType.FLOAT}`:
-        case `string->${ParameterType.FLOAT}`:
-          return parseFloat(value);
-        case `number->${ParameterType.INTEGER}`:
-        case `string->${ParameterType.INTEGER}`:
-          return parseInt(value);
-        case `array->${ParameterType.LIST}`: // ['foo', 'bar', 'baz', 'foo', ''] => ['foo', 'bar', 'baz']
-        case `string->${ParameterType.LIST}`: // 'foo,bar,baz,foo,' => ['foo', 'bar', 'baz']
-          return (current === 'string' ? value.split(',') : value)
-            .map((value) => value.trim())
-            .filter((value, index, array) => value && array.indexOf(value) === index);
-        case `array->${ParameterType.MAP}`: // ['foo=1', 'bar=2', 'baz', 'foo=3', ''] => { foo: '1', bar: '2', baz: undefined }
-        case `string->${ParameterType.MAP}`: // 'foo=1,bar=2,baz,foo=3,' => { foo: '1', bar: '2', baz: undefined }
-          return (current === 'string' ? value.split(',') : value)
-            .map((value) => value.split('=', 2).map((value) => value.trim()))
-            .filter(([key], index, array) => key && array.map(([key]) => key).indexOf(key) === index)
-            .reduce((map, [key, value]) => ({ ...map, [key]: value }), {});
-        case `object->${ParameterType.RANGE}`: // { minimum: minRange, maximum: maxRange } => [minRange, maxRange]
-        case `string->${ParameterType.RANGE}`: // 'minRange:maxRange:precision' => [minRange, maxRange, precision]
-          return (current === 'string' ? value.split(':', 3) : Object.values(value)).map((value) => parseFloat(value));
-        case `number->${ParameterType.STRING}`:
-          return value.toString();
-        case `boolean->${ParameterType.BOOLEAN}`:
-        case `object->${ParameterType.MAP}`:
-        case `array->${ParameterType.RANGE}`:
-        case `string->${ParameterType.STRING}`:
-        case 'number->undefined':
-        case 'string->undefined':
-          return value;
-      }
-    } catch {
-      // ignore conversion errors
+    switch (conversion) {
+      case `number->${ParameterType.BOOLEAN}`:
+      case `string->${ParameterType.BOOLEAN}`:
+        return ['0', 'false', 'no'].includes(value.toString().toLowerCase()) === false;
+      case `number->${ParameterType.FLOAT}`:
+      case `string->${ParameterType.FLOAT}`:
+        return parseFloat(value);
+      case `number->${ParameterType.INTEGER}`:
+      case `string->${ParameterType.INTEGER}`:
+        return parseInt(value);
+      case `array->${ParameterType.LIST}`: // ['foo', 'bar', 'baz', 'foo', ''] => ['foo', 'bar', 'baz']
+      case `string->${ParameterType.LIST}`: // 'foo,bar,baz,foo,' => ['foo', 'bar', 'baz']
+        return (current === 'string' ? value.split(',') : value)
+          .map((value) => value.trim())
+          .filter((value, index, array) => value && array.indexOf(value) === index);
+      case `array->${ParameterType.MAP}`: // ['foo=1', 'bar=2', 'baz', 'foo=3', ''] => { foo: '1', bar: '2', baz: undefined }
+      case `string->${ParameterType.MAP}`: // 'foo=1,bar=2,baz,foo=3,' => { foo: '1', bar: '2', baz: undefined }
+        return (current === 'string' ? value.split(',') : value)
+          .map((value) => value.split('=', 2).map((value) => value.trim()))
+          .filter(([key], index, array) => key && array.map(([key]) => key).indexOf(key) === index)
+          .reduce((map, [key, value]) => ({ ...map, [key]: value }), {});
+      case `object->${ParameterType.RANGE}`: // { minimum: minRange, maximum: maxRange } => [minRange, maxRange]
+      case `string->${ParameterType.RANGE}`: // 'minRange:maxRange:precision' => [minRange, maxRange, precision]
+        return (current === 'string' ? value.split(':', 3) : Object.values(value)).map((value) => parseFloat(value));
+      case `number->${ParameterType.STRING}`:
+        return value.toString();
+      case `boolean->${ParameterType.BOOLEAN}`:
+      case `object->${ParameterType.MAP}`:
+      case `array->${ParameterType.RANGE}`:
+      case `string->${ParameterType.STRING}`:
+      case 'number->undefined':
+      case 'string->undefined':
+        return value;
     }
   }
 
@@ -224,7 +220,3 @@ class AlexaMetadata {
     return match?.groups;
   }
 }
-
-module.exports = AlexaMetadata;
-module.exports.Parameter = Parameter;
-module.exports.ParameterType = ParameterType;

--- a/lambda/alexa/smarthome/properties/alarmState.js
+++ b/lambda/alexa/smarthome/properties/alarmState.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const BinaryState = require('./binaryState');
+import BinaryState from './binaryState.js';
 
 /**
  * Defines alarm state property class
  * @extends BinaryState
  */
-class AlarmState extends BinaryState {
+export default class AlarmState extends BinaryState {
   /**
    * Defines alarm state
    * @type {String}
@@ -53,5 +53,3 @@ class AlarmState extends BinaryState {
     }
   }
 }
-
-module.exports = AlarmState;

--- a/lambda/alexa/smarthome/properties/alertState.js
+++ b/lambda/alexa/smarthome/properties/alertState.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const BinaryState = require('./binaryState');
+import BinaryState from './binaryState.js';
 
 /**
  * Defines alert state property class
  * @extends BinaryState
  */
-class AlertState extends BinaryState {
+export default class AlertState extends BinaryState {
   /**
    * Defines alert state
    * @type {String}
@@ -46,5 +46,3 @@ class AlertState extends BinaryState {
     return false;
   }
 }
-
-module.exports = AlertState;

--- a/lambda/alexa/smarthome/properties/armState.js
+++ b/lambda/alexa/smarthome/properties/armState.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { clamp } from '#root/utils.js';
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines arm state authorization type enum
  * @type {Object}
  */
-const AuthType = Object.freeze({
+export const AuthType = Object.freeze({
   FOUR_DIGIT_PIN: 'FOUR_DIGIT_PIN'
 });
 
@@ -28,7 +28,7 @@ const AuthType = Object.freeze({
  * Defines arm state property class
  * @extends AlexaProperty
  */
-class ArmState extends AlexaProperty {
+export default class ArmState extends AlexaProperty {
   /**
    * Defines maximum exit delay in seconds
    * @type {Number}
@@ -190,6 +190,3 @@ class ArmState extends AlexaProperty {
       : undefined;
   }
 }
-
-module.exports = ArmState;
-module.exports.AuthType = AuthType;

--- a/lambda/alexa/smarthome/properties/binaryState.js
+++ b/lambda/alexa/smarthome/properties/binaryState.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines binary state property class
  * @extends AlexaProperty
  */
-class BinaryState extends AlexaProperty {
+export default class BinaryState extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -101,5 +101,3 @@ class BinaryState extends AlexaProperty {
     return value;
   }
 }
-
-module.exports = BinaryState;

--- a/lambda/alexa/smarthome/properties/brightness.js
+++ b/lambda/alexa/smarthome/properties/brightness.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines brightness property class
  * @extends AlexaProperty
  */
-class Brightness extends AlexaProperty {
+export default class Brightness extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -44,5 +44,3 @@ class Brightness extends AlexaProperty {
     }
   }
 }
-
-module.exports = Brightness;

--- a/lambda/alexa/smarthome/properties/cameraStream.js
+++ b/lambda/alexa/smarthome/properties/cameraStream.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines camera stream authorization type enum
  *  https://developer.amazon.com/docs/device-apis/alexa-camerastreamcontroller.html#supported-authorization
  * @type {Object}
  */
-const AuthType = Object.freeze({
+export const AuthType = Object.freeze({
   BASIC: 'BASIC',
   DIGEST: 'DIGEST',
   NONE: 'NONE'
@@ -74,7 +74,7 @@ const AudioCodec = Object.freeze({
  * Defines camera stream property class
  * @extends AlexaProperty
  */
-class CameraStream extends AlexaProperty {
+export default class CameraStream extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -188,6 +188,3 @@ class CameraStream extends AlexaProperty {
     return this.parameters[Parameter.PASSWORD] || '';
   }
 }
-
-module.exports = CameraStream;
-module.exports.AuthType = AuthType;

--- a/lambda/alexa/smarthome/properties/channel.js
+++ b/lambda/alexa/smarthome/properties/channel.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines channel property class
  * @extends AlexaProperty
  */
-class Channel extends AlexaProperty {
+export default class Channel extends AlexaProperty {
   /**
    * Defines channel number pattern
    * @type {RegExp}
@@ -124,5 +124,3 @@ class Channel extends AlexaProperty {
     parameters[Parameter.RANGE] = range[0] < range[1] ? range.map((value) => Math.round(value)) : undefined;
   }
 }
-
-module.exports = Channel;

--- a/lambda/alexa/smarthome/properties/channelStep.js
+++ b/lambda/alexa/smarthome/properties/channelStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines channel step property class
  * @extends AlexaProperty
  */
-class ChannelStep extends AlexaProperty {
+export default class ChannelStep extends AlexaProperty {
   /**
    * Defines channel step up
    * @type {String}
@@ -63,5 +63,3 @@ class ChannelStep extends AlexaProperty {
     return this.hasSupportedValuesMapped;
   }
 }
-
-module.exports = ChannelStep;

--- a/lambda/alexa/smarthome/properties/color.js
+++ b/lambda/alexa/smarthome/properties/color.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines color property class
  * @extends AlexaProperty
  */
-class Color extends AlexaProperty {
+export default class Color extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -42,5 +42,3 @@ class Color extends AlexaProperty {
     }
   }
 }
-
-module.exports = Color;

--- a/lambda/alexa/smarthome/properties/colorTemperature.js
+++ b/lambda/alexa/smarthome/properties/colorTemperature.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { clamp } = require('@root/utils');
-const { Binding, ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { clamp } from '#root/utils.js';
+import { Binding, ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines color temperature property class
  * @extends AlexaProperty
  */
-class ColorTemperature extends AlexaProperty {
+export default class ColorTemperature extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -75,7 +75,7 @@ class ColorTemperature extends AlexaProperty {
 
   /**
    * Returns binding based on parameter
-   * @return {Array}
+   * @return {String}
    */
   get binding() {
     return this.parameters[Parameter.BINDING]?.split(':')[0];
@@ -83,7 +83,7 @@ class ColorTemperature extends AlexaProperty {
 
   /**
    * Returns thing type based on parameter
-   * @return {Array}
+   * @return {String}
    */
   get thingType() {
     return this.parameters[Parameter.BINDING]?.split(':')[1];
@@ -122,7 +122,7 @@ class ColorTemperature extends AlexaProperty {
     const [minValue, maxValue] = this.range;
 
     // Return converted value based on item type:
-    //  - Dimmer: colder (0%) to warmer (100%) [bindings integration]
+    //  - Dimmer: colder (0%) to warmer (100%) [binding integration]
     //  - Number: color temperature value in K [custom integration]
     return this.item.type === ItemType.DIMMER
       ? ((maxValue - clamp(value, minValue, maxValue)) / (maxValue - minValue)) * 100
@@ -191,5 +191,3 @@ class ColorTemperature extends AlexaProperty {
     parameters[Parameter.RANGE] = range[0] < range[1] ? range.map((value) => Math.round(value)) : undefined;
   }
 }
-
-module.exports = ColorTemperature;

--- a/lambda/alexa/smarthome/properties/connectedDevice.js
+++ b/lambda/alexa/smarthome/properties/connectedDevice.js
@@ -11,18 +11,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { isMACAddress } = require('@root/utils');
-const { ItemType } = require('@openhab/constants');
-const { Capability } = require('../constants');
-const AlexaDevice = require('../device');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { isMACAddress } from '#root/utils.js';
+import { ItemType } from '#openhab/constants.js';
+import { Capability } from '../constants.js';
+import AlexaDevice from '../device/index.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines connected device property class
  * @extends AlexaProperty
  */
-class ConnectedDevice extends AlexaProperty {
+export default class ConnectedDevice extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -117,5 +117,3 @@ class ConnectedDevice extends AlexaProperty {
     parameters[Parameter.DEVICE_NAME] = metadata.config.name || item.label;
   }
 }
-
-module.exports = ConnectedDevice;

--- a/lambda/alexa/smarthome/properties/connectivity.js
+++ b/lambda/alexa/smarthome/properties/connectivity.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaProperty = require('./property');
+import AlexaProperty from './property.js';
 
 /**
  * Defines connectivity property class
  * @extends AlexaProperty
  */
-class Connectivity extends AlexaProperty {
+export default class Connectivity extends AlexaProperty {
   /**
    * Defines ok state
    * @type {String}
@@ -42,5 +42,3 @@ class Connectivity extends AlexaProperty {
     return { value: isEndpointHealthy ? Connectivity.OK : Connectivity.UNREACHABLE };
   }
 }
-
-module.exports = Connectivity;

--- a/lambda/alexa/smarthome/properties/decoupleState.js
+++ b/lambda/alexa/smarthome/properties/decoupleState.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaProperty = require('./property');
+import AlexaProperty from './property.js';
 
 /**
  * Defines decouple state property class
  * @extends AlexaProperty
  */
-class DecoupleState extends AlexaProperty {
+export default class DecoupleState extends AlexaProperty {
   /**
    * Defines decouple state tag name
    * @type {String}
@@ -41,5 +41,3 @@ class DecoupleState extends AlexaProperty {
     return [{ name: this.name, component: this.component, tag: undefined }];
   }
 }
-
-module.exports = DecoupleState;

--- a/lambda/alexa/smarthome/properties/detectionState.js
+++ b/lambda/alexa/smarthome/properties/detectionState.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const BinaryState = require('./binaryState');
+import BinaryState from './binaryState.js';
 
 /**
  * Defines detection state property class
  * @extends BinaryState
  */
-class DetectionState extends BinaryState {
+export default class DetectionState extends BinaryState {
   /**
    * Defines detected state
    * @type {String}
@@ -38,5 +38,3 @@ class DetectionState extends BinaryState {
     return [DetectionState.DETECTED, DetectionState.NOT_DETECTED];
   }
 }
-
-module.exports = DetectionState;

--- a/lambda/alexa/smarthome/properties/equalizerBands.js
+++ b/lambda/alexa/smarthome/properties/equalizerBands.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines equalizer bands property class
  * @extends AlexaProperty
  */
-class EqualizerBands extends AlexaProperty {
+export default class EqualizerBands extends AlexaProperty {
   /**
    * Defines bass equalizer band
    * @type {String}
@@ -140,5 +140,3 @@ class EqualizerBands extends AlexaProperty {
     parameters[Parameter.DEFAULT_LEVEL] = level >= this.range[0] && level <= this.range[1] ? level : undefined;
   }
 }
-
-module.exports = EqualizerBands;

--- a/lambda/alexa/smarthome/properties/equalizerMode.js
+++ b/lambda/alexa/smarthome/properties/equalizerMode.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines equalizer mode property class
  * @extends AlexaProperty
  */
-class EqualizerMode extends AlexaProperty {
+export default class EqualizerMode extends AlexaProperty {
   /**
    * Defines movie mode
    * @type {String}
@@ -144,5 +144,3 @@ class EqualizerMode extends AlexaProperty {
     parameters[Parameter.SUPPORTED_MODES] = modes?.filter((value) => this.supportedValues.includes(value));
   }
 }
-
-module.exports = EqualizerMode;

--- a/lambda/alexa/smarthome/properties/generic.js
+++ b/lambda/alexa/smarthome/properties/generic.js
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { stripPunctuation } = require('@root/utils');
-const AlexaAssetCatalog = require('../catalog');
-const { Property } = require('../constants');
-const { Parameter, ParameterType } = require('../metadata');
-const { AlexaCapabilityResources } = require('../resources');
-const { AlexaActionSemantic, AlexaStateSemantic } = require('../semantics');
-const DecoupleState = require('./decoupleState');
+import { stripPunctuation } from '#root/utils.js';
+import AlexaAssetCatalog from '../catalog.js';
+import { Property } from '../constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import { AlexaCapabilityResources } from '../resources.js';
+import { AlexaActionSemantic, AlexaStateSemantic } from '../semantics.js';
+import DecoupleState from './decoupleState.js';
 
 /**
  * Defines generic property class
  * @extends DecoupleState
  */
-class Generic extends DecoupleState {
+export default class Generic extends DecoupleState {
   /**
    * Returns supported parameters and their type
    * @return {Object}
@@ -179,5 +179,3 @@ class Generic extends DecoupleState {
       .reduce((states, [state, mapping]) => ({ ...states, [state]: mapping }), undefined);
   }
 }
-
-module.exports = Generic;

--- a/lambda/alexa/smarthome/properties/index.js
+++ b/lambda/alexa/smarthome/properties/index.js
@@ -12,49 +12,46 @@
  */
 
 /**
- * Defines supported property classes
- * @type {Object}
+ * Exports supported property classes
  */
-module.exports = {
-  AlarmState: require('./alarmState'),
-  AlertState: require('./alertState'),
-  ArmState: require('./armState'),
-  BinaryState: require('./binaryState'),
-  Brightness: require('./brightness'),
-  CameraStream: require('./cameraStream'),
-  Channel: require('./channel'),
-  ChannelStep: require('./channelStep'),
-  Color: require('./color'),
-  ColorTemperature: require('./colorTemperature'),
-  ConnectedDevice: require('./connectedDevice'),
-  Connectivity: require('./connectivity'),
-  DecoupleState: require('./decoupleState'),
-  DetectionState: require('./detectionState'),
-  EqualizerBands: require('./equalizerBands'),
-  EqualizerMode: require('./equalizerMode'),
-  Generic: require('./generic'),
-  Input: require('./input'),
-  LockState: require('./lockState'),
-  LowerSetpoint: require('./lowerSetpoint'),
-  Mode: require('./mode'),
-  MuteState: require('./muteState'),
-  MuteStep: require('./muteStep'),
-  NetworkAccess: require('./networkAccess'),
-  Percentage: require('./percentage'),
-  Playback: require('./playback'),
-  PlaybackAction: require('./playbackAction'),
-  PlaybackStop: require('./playbackStop'),
-  PowerLevel: require('./powerLevel'),
-  PowerState: require('./powerState'),
-  RangeValue: require('./rangeValue'),
-  Scene: require('./scene'),
-  SecurityAlert: require('./securityAlert'),
-  TargetSetpoint: require('./targetSetpoint'),
-  Temperature: require('./temperature'),
-  ThermostatHold: require('./thermostatHold'),
-  ThermostatMode: require('./thermostatMode'),
-  ToggleState: require('./toggleState'),
-  UpperSetpoint: require('./upperSetpoint'),
-  VolumeLevel: require('./volumeLevel'),
-  VolumeStep: require('./volumeStep')
-};
+export { default as AlarmState } from './alarmState.js';
+export { default as AlertState } from './alertState.js';
+export { default as ArmState } from './armState.js';
+export { default as BinaryState } from './binaryState.js';
+export { default as Brightness } from './brightness.js';
+export { default as CameraStream } from './cameraStream.js';
+export { default as Channel } from './channel.js';
+export { default as ChannelStep } from './channelStep.js';
+export { default as Color } from './color.js';
+export { default as ColorTemperature } from './colorTemperature.js';
+export { default as ConnectedDevice } from './connectedDevice.js';
+export { default as Connectivity } from './connectivity.js';
+export { default as DecoupleState } from './decoupleState.js';
+export { default as DetectionState } from './detectionState.js';
+export { default as EqualizerBands } from './equalizerBands.js';
+export { default as EqualizerMode } from './equalizerMode.js';
+export { default as Generic } from './generic.js';
+export { default as Input } from './input.js';
+export { default as LockState } from './lockState.js';
+export { default as LowerSetpoint } from './lowerSetpoint.js';
+export { default as Mode } from './mode.js';
+export { default as MuteState } from './muteState.js';
+export { default as MuteStep } from './muteStep.js';
+export { default as NetworkAccess } from './networkAccess.js';
+export { default as Percentage } from './percentage.js';
+export { default as Playback } from './playback.js';
+export { default as PlaybackAction } from './playbackAction.js';
+export { default as PlaybackStop } from './playbackStop.js';
+export { default as PowerLevel } from './powerLevel.js';
+export { default as PowerState } from './powerState.js';
+export { default as RangeValue } from './rangeValue.js';
+export { default as Scene } from './scene.js';
+export { default as SecurityAlert } from './securityAlert.js';
+export { default as TargetSetpoint } from './targetSetpoint.js';
+export { default as Temperature } from './temperature.js';
+export { default as ThermostatHold } from './thermostatHold.js';
+export { default as ThermostatMode } from './thermostatMode.js';
+export { default as ToggleState } from './toggleState.js';
+export { default as UpperSetpoint } from './upperSetpoint.js';
+export { default as VolumeLevel } from './volumeLevel.js';
+export { default as VolumeStep } from './volumeStep.js';

--- a/lambda/alexa/smarthome/properties/input.js
+++ b/lambda/alexa/smarthome/properties/input.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines input property class
  * @extends AlexaProperty
  */
-class Input extends AlexaProperty {
+export default class Input extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -99,5 +99,3 @@ class Input extends AlexaProperty {
       .filter(Boolean);
   }
 }
-
-module.exports = Input;

--- a/lambda/alexa/smarthome/properties/lockState.js
+++ b/lambda/alexa/smarthome/properties/lockState.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const DecoupleState = require('./decoupleState');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import DecoupleState from './decoupleState.js';
 
 /**
  * Defines lock state property class
  * @extends DecoupleState
  */
-class LockState extends DecoupleState {
+export default class LockState extends DecoupleState {
   /**
    * Defines locked state
    * @type {String}
@@ -130,5 +130,3 @@ class LockState extends DecoupleState {
     return value;
   }
 }
-
-module.exports = LockState;

--- a/lambda/alexa/smarthome/properties/lowerSetpoint.js
+++ b/lambda/alexa/smarthome/properties/lowerSetpoint.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Property } = require('../constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaUnitOfMeasure = require('../unitOfMeasure');
-const TargetSetpoint = require('./targetSetpoint');
-const ThermostatMode = require('./thermostatMode');
+import { Property } from '../constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaUnitOfMeasure from '../unitOfMeasure.js';
+import TargetSetpoint from './targetSetpoint.js';
+import ThermostatMode from './thermostatMode.js';
 
 /**
  * Defines lower setpoint property class
  * @extends TargetSetpoint
  */
-class LowerSetpoint extends TargetSetpoint {
+export default class LowerSetpoint extends TargetSetpoint {
   /**
    * Returns supported parameters and their type
    * @return {Object}
@@ -83,5 +83,3 @@ class LowerSetpoint extends TargetSetpoint {
     parameters[Parameter.COMFORT_RANGE] = range < maxRange ? range : undefined;
   }
 }
-
-module.exports = LowerSetpoint;

--- a/lambda/alexa/smarthome/properties/mode.js
+++ b/lambda/alexa/smarthome/properties/mode.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const AlexaAssetCatalog = require('../catalog');
-const { Parameter, ParameterType } = require('../metadata');
-const { AlexaModeResources } = require('../resources');
-const Generic = require('./generic');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import AlexaAssetCatalog from '../catalog.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import { AlexaModeResources } from '../resources.js';
+import Generic from './generic.js';
 
 /**
  * Defines mode property class
  * @extends Generic
  */
-class Mode extends Generic {
+export default class Mode extends Generic {
   /**
    * Defines supported modes limit
    * @type {Number}
@@ -212,5 +212,3 @@ class Mode extends Generic {
     delete parameters[Parameter.SUPPORTED_COMMANDS];
   }
 }
-
-module.exports = Mode;

--- a/lambda/alexa/smarthome/properties/muteState.js
+++ b/lambda/alexa/smarthome/properties/muteState.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines mute state property class
  * @extends AlexaProperty
  */
-class MuteState extends AlexaProperty {
+export default class MuteState extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -67,5 +67,3 @@ class MuteState extends AlexaProperty {
     }
   }
 }
-
-module.exports = MuteState;

--- a/lambda/alexa/smarthome/properties/muteStep.js
+++ b/lambda/alexa/smarthome/properties/muteStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines mute step property class
  * @extends AlexaProperty
  */
-class MuteStep extends AlexaProperty {
+export default class MuteStep extends AlexaProperty {
   /**
    * Defines mute step
    * @type {String}
@@ -57,5 +57,3 @@ class MuteStep extends AlexaProperty {
     return this.hasSupportedValuesMapped;
   }
 }
-
-module.exports = MuteStep;

--- a/lambda/alexa/smarthome/properties/networkAccess.js
+++ b/lambda/alexa/smarthome/properties/networkAccess.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const BinaryState = require('./binaryState');
+import BinaryState from './binaryState.js';
 
 /**
  * Defines network access property class
  * @extends BinaryState
  */
-class NetworkAccess extends BinaryState {
+export default class NetworkAccess extends BinaryState {
   /**
    * Defines allowed state
    * @type {String}
@@ -47,5 +47,3 @@ class NetworkAccess extends BinaryState {
     return true;
   }
 }
-
-module.exports = NetworkAccess;

--- a/lambda/alexa/smarthome/properties/percentage.js
+++ b/lambda/alexa/smarthome/properties/percentage.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines percentage property class
  * @extends AlexaProperty
  */
-class Percentage extends AlexaProperty {
+export default class Percentage extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -81,5 +81,3 @@ class Percentage extends AlexaProperty {
     }
   }
 }
-
-module.exports = Percentage;

--- a/lambda/alexa/smarthome/properties/playback.js
+++ b/lambda/alexa/smarthome/properties/playback.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines playback property class
  * @extends AlexaProperty
  */
-class Playback extends AlexaProperty {
+export default class Playback extends AlexaProperty {
   /**
    * Defines play operation
    * @type {String}
@@ -152,5 +152,3 @@ class Playback extends AlexaProperty {
     parameters[Parameter.SUPPORTED_OPERATIONS] = operations?.filter((value) => this.defaultOperations.includes(value));
   }
 }
-
-module.exports = Playback;

--- a/lambda/alexa/smarthome/properties/playbackAction.js
+++ b/lambda/alexa/smarthome/properties/playbackAction.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const { CustomActionSemantic } = require('../semantics');
-const AlexaProperty = require('./property');
-const Playback = require('./playback');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import { CustomActionSemantic } from '../semantics.js';
+import AlexaProperty from './property.js';
+import Playback from './playback.js';
 
 /**
  * Defines playback action property class
  * @extends AlexaProperty
  */
-class PlaybackAction extends AlexaProperty {
+export default class PlaybackAction extends AlexaProperty {
   /**
    * Defines pause state
    * @type {String}
@@ -144,5 +144,3 @@ class PlaybackAction extends AlexaProperty {
     delete parameters[Parameter.ACTION_MAPPINGS];
   }
 }
-
-module.exports = PlaybackAction;

--- a/lambda/alexa/smarthome/properties/playbackStop.js
+++ b/lambda/alexa/smarthome/properties/playbackStop.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Property } = require('../constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
-const Playback = require('./playback');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Property } from '../constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
+import Playback from './playback.js';
 
 /**
  * Defines playback stop property class
  * @extends AlexaProperty
  */
-class PlaybackStop extends AlexaProperty {
+export default class PlaybackStop extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -80,5 +80,3 @@ class PlaybackStop extends AlexaProperty {
     return this.inverted ? ItemValue.OFF : ItemValue.ON;
   }
 }
-
-module.exports = PlaybackStop;

--- a/lambda/alexa/smarthome/properties/powerLevel.js
+++ b/lambda/alexa/smarthome/properties/powerLevel.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines power level property class
  * @extends AlexaProperty
  */
-class PowerLevel extends AlexaProperty {
+export default class PowerLevel extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -39,5 +39,3 @@ class PowerLevel extends AlexaProperty {
     }
   }
 }
-
-module.exports = PowerLevel;

--- a/lambda/alexa/smarthome/properties/powerState.js
+++ b/lambda/alexa/smarthome/properties/powerState.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const { CustomActionSemantic } = require('../semantics');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import { CustomActionSemantic } from '../semantics.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines power state property class
  * @extends AlexaProperty
  */
-class PowerState extends AlexaProperty {
+export default class PowerState extends AlexaProperty {
   /**
    * Defines on state
    * @type {String}
@@ -145,5 +145,3 @@ class PowerState extends AlexaProperty {
     delete parameters[Parameter.ACTION_MAPPINGS];
   }
 }
-
-module.exports = PowerState;

--- a/lambda/alexa/smarthome/properties/property.js
+++ b/lambda/alexa/smarthome/properties/property.js
@@ -11,12 +11,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { convertValue, Parameter, ParameterType } = require('../metadata');
+import AlexaMetadata, { Parameter, ParameterType } from '../metadata.js';
 
 /**
  * Defines alexa property base class
  */
-class AlexaProperty {
+export default class AlexaProperty {
   /**
    * Defines default alias parameters for backward compatibility
    * @type {Object}
@@ -261,7 +261,7 @@ class AlexaProperty {
       // Determine property parameter value type
       const type = this.getParameterType(name);
       // Update property parameter with converted value
-      parameters[name] = convertValue(value, type);
+      parameters[name] = AlexaMetadata.convertValue(value, type);
     }
   }
 
@@ -287,7 +287,10 @@ class AlexaProperty {
 
     // Use autoupdate metadata value if available, to determine retrievable parameter if not already defined
     if (typeof parameters[Parameter.RETRIEVABLE] !== 'boolean' && item.metadata?.autoupdate) {
-      parameters[Parameter.RETRIEVABLE] = convertValue(item.metadata.autoupdate.value, ParameterType.BOOLEAN);
+      parameters[Parameter.RETRIEVABLE] = AlexaMetadata.convertValue(
+        item.metadata.autoupdate.value,
+        ParameterType.BOOLEAN
+      );
     }
   }
 
@@ -317,7 +320,7 @@ class AlexaProperty {
    * @param  {Array}  groups
    * @return {Object}
    */
-  static build({ name, component, tag, parameters, item, metadata, settings, groups }) {
+  static create({ name, component, tag, parameters, item, metadata, settings, groups }) {
     const property = new this(name, component, tag, parameters, item);
 
     // Return if property has not required component or supported item type
@@ -335,5 +338,3 @@ class AlexaProperty {
     return property;
   }
 }
-
-module.exports = AlexaProperty;

--- a/lambda/alexa/smarthome/properties/rangeValue.js
+++ b/lambda/alexa/smarthome/properties/rangeValue.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const { AlexaPresetResources } = require('../resources');
-const AlexaUnitOfMeasure = require('../unitOfMeasure');
-const Generic = require('./generic');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import { AlexaPresetResources } from '../resources.js';
+import AlexaUnitOfMeasure from '../unitOfMeasure.js';
+import Generic from './generic.js';
 
 /**
  * Defines range value property class
  * @extends Generic
  */
-class RangeValue extends Generic {
+export default class RangeValue extends Generic {
   /**
    * Defines presets limit
    * @type {Number}
@@ -230,5 +230,3 @@ class RangeValue extends Generic {
     parameters[Parameter.UNIT_OF_MEASURE] = AlexaUnitOfMeasure.isSupported(uom) ? uom : undefined;
   }
 }
-
-module.exports = RangeValue;

--- a/lambda/alexa/smarthome/properties/scene.js
+++ b/lambda/alexa/smarthome/properties/scene.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines scene property class
  * @extends AlexaProperty
  */
-class Scene extends AlexaProperty {
+export default class Scene extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -54,5 +54,3 @@ class Scene extends AlexaProperty {
     return this.parameters[Parameter.SUPPORTS_DEACTIVATION] !== false;
   }
 }
-
-module.exports = Scene;

--- a/lambda/alexa/smarthome/properties/securityAlert.js
+++ b/lambda/alexa/smarthome/properties/securityAlert.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Property } = require('../constants');
-const AlertState = require('./alertState');
+import { Property } from '../constants.js';
+import AlertState from './alertState.js';
 
 /**
  * Defines security alert property class
  * @extends AlertState
  */
-class SecurityAlert extends AlertState {
+export default class SecurityAlert extends AlertState {
   /**
    * Returns required linked properties
    * @return {Array}
@@ -27,5 +27,3 @@ class SecurityAlert extends AlertState {
     return [{ name: Property.ARM_STATE }];
   }
 }
-
-module.exports = SecurityAlert;

--- a/lambda/alexa/smarthome/properties/targetSetpoint.js
+++ b/lambda/alexa/smarthome/properties/targetSetpoint.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaUnitOfMeasure = require('../unitOfMeasure');
-const Temperature = require('./temperature');
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaUnitOfMeasure from '../unitOfMeasure.js';
+import Temperature from './temperature.js';
 
 /**
  * Defines target setpoint property class
  * @extends Temperature
  */
-class TargetSetpoint extends Temperature {
+export default class TargetSetpoint extends Temperature {
   /**
    * Defines default setpoint range in celsius
    * @type {Array}
@@ -77,5 +77,3 @@ class TargetSetpoint extends Temperature {
     parameters[Parameter.SETPOINT_RANGE] = range[0] < range[1] ? range : undefined;
   }
 }
-
-module.exports = TargetSetpoint;

--- a/lambda/alexa/smarthome/properties/temperature.js
+++ b/lambda/alexa/smarthome/properties/temperature.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Dimension, ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaUnitOfMeasure = require('../unitOfMeasure');
-const AlexaProperty = require('./property');
+import { Dimension, ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaUnitOfMeasure from '../unitOfMeasure.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines temperature property class
  * @extends AlexaProperty
  */
-class Temperature extends AlexaProperty {
+export default class Temperature extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -110,5 +110,3 @@ class Temperature extends AlexaProperty {
         : AlexaUnitOfMeasure.UNIT_CELSIUS;
   }
 }
-
-module.exports = Temperature;

--- a/lambda/alexa/smarthome/properties/thermostatHold.js
+++ b/lambda/alexa/smarthome/properties/thermostatHold.js
@@ -11,16 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType, ItemValue } = require('@openhab/constants');
-const { Property } = require('../constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType, ItemValue } from '#openhab/constants.js';
+import { Property } from '../constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines thermostat hold property class
  * @extends AlexaProperty
  */
-class ThermostatHold extends AlexaProperty {
+export default class ThermostatHold extends AlexaProperty {
   /**
    * Defines on state
    * @type {String}
@@ -124,5 +124,3 @@ class ThermostatHold extends AlexaProperty {
     return super.getCommand(value);
   }
 }
-
-module.exports = ThermostatHold;

--- a/lambda/alexa/smarthome/properties/thermostatMode.js
+++ b/lambda/alexa/smarthome/properties/thermostatMode.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Binding, ItemType, ItemValue } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { Binding, ItemType, ItemValue } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines thermostat mode property class
  * @extends AlexaProperty
  */
-class ThermostatMode extends AlexaProperty {
+export default class ThermostatMode extends AlexaProperty {
   /**
    * Defines auto mode
    * @type {String}
@@ -235,5 +235,3 @@ class ThermostatMode extends AlexaProperty {
     parameters[Parameter.SUPPORTED_MODES] = modes?.filter((value) => this.supportedValues.includes(value));
   }
 }
-
-module.exports = ThermostatMode;

--- a/lambda/alexa/smarthome/properties/toggleState.js
+++ b/lambda/alexa/smarthome/properties/toggleState.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const Generic = require('./generic');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import Generic from './generic.js';
 
 /**
  * Defines toggle state property class
  * @extends Generic
  */
-class ToggleState extends Generic {
+export default class ToggleState extends Generic {
   /**
    * Defines on state
    * @type {String}
@@ -121,5 +121,3 @@ class ToggleState extends Generic {
     return value;
   }
 }
-
-module.exports = ToggleState;

--- a/lambda/alexa/smarthome/properties/upperSetpoint.js
+++ b/lambda/alexa/smarthome/properties/upperSetpoint.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { Property } = require('../constants');
-const LowerSetpoint = require('./lowerSetpoint');
+import { Property } from '../constants.js';
+import LowerSetpoint from './lowerSetpoint.js';
 
 /**
  * Defines upper setpoint property class
  * @extends LowerSetpoint
  */
-class UpperSetpoint extends LowerSetpoint {
+export default class UpperSetpoint extends LowerSetpoint {
   /**
    * Returns required linked properties
    * @return {Array}
@@ -27,5 +27,3 @@ class UpperSetpoint extends LowerSetpoint {
     return [{ name: Property.LOWER_SETPOINT, tag: this.tag }];
   }
 }
-
-module.exports = UpperSetpoint;

--- a/lambda/alexa/smarthome/properties/volumeLevel.js
+++ b/lambda/alexa/smarthome/properties/volumeLevel.js
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const { Parameter, ParameterType } = require('../metadata');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import { Parameter, ParameterType } from '../metadata.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines volume level property class
  * @extends AlexaProperty
  */
-class VolumeLevel extends AlexaProperty {
+export default class VolumeLevel extends AlexaProperty {
   /**
    * Returns supported item types
    * @return {Array}
@@ -58,5 +58,3 @@ class VolumeLevel extends AlexaProperty {
     }
   }
 }
-
-module.exports = VolumeLevel;

--- a/lambda/alexa/smarthome/properties/volumeStep.js
+++ b/lambda/alexa/smarthome/properties/volumeStep.js
@@ -11,14 +11,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { ItemType } = require('@openhab/constants');
-const AlexaProperty = require('./property');
+import { ItemType } from '#openhab/constants.js';
+import AlexaProperty from './property.js';
 
 /**
  * Defines volume step property class
  * @extends AlexaProperty
  */
-class VolumeStep extends AlexaProperty {
+export default class VolumeStep extends AlexaProperty {
   /**
    * Defines volume step up
    * @type {String}
@@ -63,5 +63,3 @@ class VolumeStep extends AlexaProperty {
     return this.hasSupportedValuesMapped;
   }
 }
-
-module.exports = VolumeStep;

--- a/lambda/alexa/smarthome/resources.js
+++ b/lambda/alexa/smarthome/resources.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const AlexaAssetCatalog = require('./catalog');
+import AlexaAssetCatalog from './catalog.js';
 
 /**
  * Defines alexa capability resources class
  *  https://developer.amazon.com/docs/device-apis/resources-and-assets.html#capability-resources
  */
-class AlexaCapabilityResources {
+export class AlexaCapabilityResources {
   /**
    * Defines asset label prefix
    * @type {String}
@@ -135,7 +135,7 @@ class AlexaCapabilityResources {
  *  https://developer.amazon.com/docs/device-apis/resources-and-assets.html#mode-resources
  * @extends AlexaCapabilityResource
  */
-class AlexaModeResources extends AlexaCapabilityResources {
+export class AlexaModeResources extends AlexaCapabilityResources {
   /**
    * Defines alexa reserved friendly names
    *  (None for mode resources)
@@ -149,7 +149,7 @@ class AlexaModeResources extends AlexaCapabilityResources {
  *  https://developer.amazon.com/docs/device-apis/resources-and-assets.html#preset-resources
  * @extends AlexaCapabilityResource
  */
-class AlexaPresetResources extends AlexaCapabilityResources {
+export class AlexaPresetResources extends AlexaCapabilityResources {
   /**
    * Defines alexa reserved friendly names
    *  (None for preset resources)
@@ -157,9 +157,3 @@ class AlexaPresetResources extends AlexaCapabilityResources {
    */
   static FRIENDLY_NAMES_RESERVED = [];
 }
-
-module.exports = {
-  AlexaCapabilityResources,
-  AlexaModeResources,
-  AlexaPresetResources
-};

--- a/lambda/alexa/smarthome/response.js
+++ b/lambda/alexa/smarthome/response.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { v4: uuidv4 } = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Defines alexa response class
  *  https://developer.amazon.com/docs/device-apis/alexa-response.html
  */
-class AlexaResponse {
+export default class AlexaResponse {
   /**
    * Defines response timeout in milliseconds
    * @type {Number}
@@ -85,5 +85,3 @@ class AlexaResponse {
     return this._response;
   }
 }
-
-module.exports = AlexaResponse;

--- a/lambda/alexa/smarthome/semantics.js
+++ b/lambda/alexa/smarthome/semantics.js
@@ -15,7 +15,7 @@
  * Defines alexa semantics class
  *  https://developer.amazon.com/docs/alexa-voice-service/generic-controllers.html#semantics
  */
-class AlexaSemantics {
+export default class AlexaSemantics {
   /**
    * Constructor
    */
@@ -31,7 +31,7 @@ class AlexaSemantics {
   addActionToDirective(name, directive) {
     const actionMappings = this._semantics.actionMappings;
     // Define alexa action semantic id
-    const action = AlexaActionSemantic.get(name);
+    const action = AlexaActionSemantic.getId(name);
     // Find defined action mappings index with same directive
     const index = actionMappings.findIndex((map) => JSON.stringify(map.directive) === JSON.stringify(directive));
     // Update existing mapping actions list if found, otherwise add new mapping
@@ -54,7 +54,7 @@ class AlexaSemantics {
   addStateToRange(name, range) {
     const stateMappings = this._semantics.stateMappings;
     // Define alexa state semantic id
-    const state = AlexaStateSemantic.get(name);
+    const state = AlexaStateSemantic.getId(name);
     // Find defined state mappings index with same range
     const index = stateMappings.findIndex((map) => JSON.stringify(map.range) === JSON.stringify(range));
     // Update existing mapping states list if found, otherwise add new mapping
@@ -77,7 +77,7 @@ class AlexaSemantics {
   addStateToValue(name, value) {
     const stateMappings = this._semantics.stateMappings;
     // Define alexa state semantic id
-    const state = AlexaStateSemantic.get(name);
+    const state = AlexaStateSemantic.getId(name);
     // Find defined state mappings index with same value
     const index = stateMappings.findIndex((map) => map.value === value);
     // Update existing mapping states list if found, otherwise add new mapping
@@ -109,7 +109,7 @@ class AlexaSemantics {
 /**
  * Defines alexa action semantic class
  */
-class AlexaActionSemantic {
+export class AlexaActionSemantic {
   /**
    * Defines open action semantic
    * @type {String}
@@ -139,7 +139,7 @@ class AlexaActionSemantic {
    * @param  {String} name
    * @return {String}
    */
-  static get(name) {
+  static getId(name) {
     return 'Alexa.Actions.' + name;
   }
 }
@@ -147,7 +147,7 @@ class AlexaActionSemantic {
 /**
  * Defines alexa state semantic class
  */
-class AlexaStateSemantic {
+export class AlexaStateSemantic {
   /**
    * Defines open state semantic
    * @type {String}
@@ -165,7 +165,7 @@ class AlexaStateSemantic {
    * @param  {String} name
    * @return {String}
    */
-  static get(name) {
+  static getId(name) {
     return 'Alexa.States.' + name;
   }
 }
@@ -173,7 +173,7 @@ class AlexaStateSemantic {
 /**
  * Defines custom action semantic class
  */
-class CustomActionSemantic {
+export class CustomActionSemantic {
   /**
    * Defines resume action semantic
    * @type {String}
@@ -204,8 +204,3 @@ class CustomActionSemantic {
    */
   static TURN_OFF = 'TurnOff';
 }
-
-module.exports = AlexaSemantics;
-module.exports.AlexaActionSemantic = AlexaActionSemantic;
-module.exports.AlexaStateSemantic = AlexaStateSemantic;
-module.exports.CustomActionSemantic = CustomActionSemantic;

--- a/lambda/alexa/smarthome/unitOfMeasure.js
+++ b/lambda/alexa/smarthome/unitOfMeasure.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { sprintf } = require('sprintf-js');
-const { Dimension, SymbolUnit, SystemUnit } = require('@openhab/constants');
+import { sprintf } from 'sprintf-js';
+import { Dimension, SymbolUnit, SystemUnit } from '#openhab/constants.js';
 
 /**
  * Defines Alexa unit of measure class
  */
-class AlexaUnitOfMeasure {
+export default class AlexaUnitOfMeasure {
   /**
    * Defines angle degrees id
    * @type {String}
@@ -506,5 +506,3 @@ class AlexaUnitOfMeasure {
     }
   }
 }
-
-module.exports = AlexaUnitOfMeasure;

--- a/lambda/config.js
+++ b/lambda/config.js
@@ -41,7 +41,7 @@
  *
  * @type {Object}
  */
-module.exports = {
+export default {
   openhab: {
     baseURL: process.env.OPENHAB_BASE_URL || 'https://myopenhab.org',
     user: process.env.OPENHAB_USERNAME || '',

--- a/lambda/index.js
+++ b/lambda/index.js
@@ -11,20 +11,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-require('module-alias/register');
-const log = require('./log');
-const AlexaSmarthome = require('./alexa/smarthome');
+import log from './log.js';
+import { handleRequest } from './alexa/smarthome/index.js';
 
 /**
  * Defines skill event handler
  * @param  {Object}  event
  * @return {Promise}
  */
-exports.handler = async (event) => {
+export const handler = async (event) => {
   log.info('Received event:', event);
 
   if (event.directive?.header.payloadVersion === '3') {
-    return AlexaSmarthome.handleRequest(event);
+    return handleRequest(event);
   }
 
   log.warn('Unsupported event:', event);

--- a/lambda/log.js
+++ b/lambda/log.js
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-/* istanbul ignore file */
-const { createLogger, format, transports } = require('winston');
+import { createLogger, format, transports } from 'winston';
 
 const LEVEL = Symbol.for('level');
 const MESSAGE = Symbol.for('message');
 
-const logger = createLogger({
+/* c8 ignore start */
+export default createLogger({
   level: !process.env.LOG_LEVEL || process.env.NODE_ENV === 'test' ? 'error' : process.env.LOG_LEVEL.toLowerCase(),
   levels: { error: 0, warn: 1, info: 2, debug: 3 },
   format: format.printf(
@@ -39,5 +39,3 @@ const logger = createLogger({
     })
   ]
 });
-
-module.exports = logger;

--- a/lambda/openhab/constants.js
+++ b/lambda/openhab/constants.js
@@ -16,7 +16,7 @@
  *  https://www.openhab.org/addons/
  * @type {Object}
  */
-const Binding = Object.freeze({
+export const Binding = Object.freeze({
   BROADLINK_THERMOSTAT: 'broadlinkthermostat',
   DAIKIN: 'daikin',
   ECOBEE: 'ecobee',
@@ -39,7 +39,7 @@ const Binding = Object.freeze({
  *  https://www.openhab.org/docs/concepts/units-of-measurement.html
  * @type {Object}
  */
-const Dimension = Object.freeze({
+export const Dimension = Object.freeze({
   ANGLE: 'Angle',
   DIMENSIONLESS: 'Dimensionless',
   LENGTH: 'Length',
@@ -53,7 +53,7 @@ const Dimension = Object.freeze({
  *  https://www.openhab.org/docs/concepts/items.html
  * @type {Object}
  */
-const ItemType = Object.freeze({
+export const ItemType = Object.freeze({
   COLOR: 'Color',
   CONTACT: 'Contact',
   DIMMER: 'Dimmer',
@@ -76,7 +76,7 @@ const ItemType = Object.freeze({
  *  https://www.openhab.org/docs/concepts/items.html#enum-types
  * @type {Object}
  */
-const ItemValue = Object.freeze({
+export const ItemValue = Object.freeze({
   INCREASE: 'INCREASE',
   DECREASE: 'DECREASE',
   NEXT: 'NEXT',
@@ -102,7 +102,7 @@ const ItemValue = Object.freeze({
  *  https://www.openhab.org/docs/concepts/units-of-measurement.html#list-of-units
  * @type {Object}
  */
-const SymbolUnit = Object.freeze({
+export const SymbolUnit = Object.freeze({
   DEGREE: '°',
   RADIAN: 'rad',
   PERCENT: '%',
@@ -132,16 +132,7 @@ const SymbolUnit = Object.freeze({
  *  https://www.openhab.org/docs/concepts/units-of-measurement.html#list-of-units
  * @type {Object}
  */
-const SystemUnit = Object.freeze({
+export const SystemUnit = Object.freeze({
   METRIC: 'SI',
   IMPERIAL_US: 'US'
 });
-
-module.exports = {
-  Binding,
-  Dimension,
-  ItemType,
-  ItemValue,
-  SymbolUnit,
-  SystemUnit
-};

--- a/lambda/openhab/index.js
+++ b/lambda/openhab/index.js
@@ -11,17 +11,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const fs = require('fs');
-const request = require('request-promise-native');
-const Agent = require('agentkeepalive');
-const { sprintf } = require('sprintf-js');
-const { validate: uuidValidate } = require('uuid');
-const { ItemValue } = require('./constants');
+import fs from 'fs';
+import request from 'request-promise-native';
+import Agent from 'agentkeepalive';
+import { sprintf } from 'sprintf-js';
+import { validate as uuidValidate } from 'uuid';
+import { ItemType, ItemValue } from './constants.js';
 
 /**
  * Defines openHAB class
  */
-class OpenHAB {
+export default class OpenHAB {
   /**
    * Constructor
    * @param {Object} config
@@ -213,11 +213,11 @@ class OpenHAB {
     if (format) {
       try {
         switch (type.split(':')[0]) {
-          case 'Dimmer':
-          case 'Number':
-          case 'Rollershutter':
+          case ItemType.DIMMER:
+          case ItemType.NUMBER:
+          case ItemType.ROLLERSHUTTER:
             return sprintf(format[0], parseFloat(state));
-          case 'String':
+          case ItemType.STRING:
             return sprintf(format[0], state);
         }
       } catch {
@@ -266,5 +266,3 @@ class OpenHAB {
     return request.defaults(options);
   }
 }
-
-module.exports = OpenHAB;

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -1,289 +1,3006 @@
 {
-  "name": "openHAB.alexa-smarthome",
+  "name": "openhab-alexa",
   "version": "3.2.3",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
-      }
-    },
-    "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.16.7"
-      }
-    },
-    "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
-      "dev": true
-    },
-    "@babel/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
-      "dev": true,
-      "requires": {
-        "@ampproject/remapping": "^2.0.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.0",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.16.4",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-      "dev": true
-    },
-    "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true
-    },
-    "@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
-        "@babel/types": "^7.17.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      },
+  "packages": {
+    "": {
+      "name": "openhab-alexa",
+      "version": "3.2.3",
+      "license": "EPL-2.0",
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
+        "agentkeepalive": "^4.2.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.9",
+        "sprintf-js": "^1.1.2",
+        "uuid": "^9.0.0",
+        "winston": "^3.8.2"
+      },
+      "devDependencies": {
+        "ajv": "^6.12.6",
+        "c8": "^7.12.0",
+        "chai": "^4.3.7",
+        "chai-subset": "^1.6.0",
+        "eslint": "^8.30.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-n": "^15.6.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "esmock": "^2.1.0",
+        "mocha": "^10.2.0",
+        "nock": "^13.2.9",
+        "prettier": "^2.8.1",
+        "sinon": "^15.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+      "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.4.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/c8": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.12.0.tgz",
+      "integrity": "sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-reports": "^3.1.4",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-subset": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
+      "integrity": "sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+          "optional": true
         }
       }
     },
-    "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
-    "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
-        "@babel/types": "^7.17.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "dependencies": {
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+      "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.4.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.0.tgz",
+      "integrity": "sha512-Hd/F7wz4Mj44Jp0H6Jtty13NcE69GNTY0rVlgTIj1XBnGGVI6UTdDrpE6vqu3AHo07bygq/N+7OH/lgz1emUJw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
         }
       }
     },
-    "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "to-fast-properties": "^2.0.0"
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esmock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.1.0.tgz",
+      "integrity": "sha512-8/2+iFfcB5FMJDBWXmXCY/4GSaI8sMCWUmq2laroQc3y9AI53QMm5Ew25DkW9FMaM8dBH8hmvOr2l3qChJ2JgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.2.tgz",
+      "integrity": "sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
+      "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
+      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
+  "dependencies": {
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -301,37 +3018,26 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+      "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -351,95 +3057,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
-        }
-      }
-    },
     "@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -447,25 +3064,25 @@
       "dev": true
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -504,23 +3121,12 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "@sinonjs/samsam": {
@@ -540,6 +3146,12 @@
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -550,7 +3162,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agentkeepalive": {
       "version": "4.2.1",
@@ -560,16 +3173,6 @@
         "debug": "^4.1.0",
         "depd": "^1.1.2",
         "humanize-ms": "^1.2.1"
-      }
-    },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -602,49 +3205,17 @@
       "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "append-transform": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "^3.0.0"
-      }
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -663,7 +3234,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -679,12 +3250,12 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
       "version": "1.11.0",
@@ -700,7 +3271,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -736,29 +3307,33 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
-        "picocolors": "^1.0.0"
+        "semver": "^7.0.0"
       }
     },
-    "caching-transform": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+    "c8": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.12.0.tgz",
+      "integrity": "sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==",
       "dev": true,
       "requires": {
-        "hasha": "^5.0.0",
-        "make-dir": "^3.0.0",
-        "package-hash": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-reports": "^3.1.4",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9"
       }
     },
     "callsites": {
@@ -773,16 +3348,10 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
-    "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chai": {
       "version": "4.3.7",
@@ -802,7 +3371,7 @@
     "chai-subset": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
-      "integrity": "sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=",
+      "integrity": "sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==",
       "dev": true
     },
     "chalk": {
@@ -848,12 +3417,6 @@
         }
       }
     },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -872,20 +3435,36 @@
       "requires": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        }
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
       "version": "1.9.1",
@@ -913,39 +3492,22 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -961,15 +3523,15 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -981,9 +3543,9 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
-      "integrity": "sha512-gT18+YW4CcW/DBNTwAmqTtkJh7f9qqScu2qFVlx7kCoeY9tlBu9cUcr7+I+Z/noG8INehS3xQgLpTtd/QUTn4w==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -995,24 +3557,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
-      "dev": true,
-      "requires": {
-        "strip-bom": "^4.0.0"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
     "diff": {
       "version": "5.0.0",
@@ -1032,17 +3585,11 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
-    },
-    "electron-to-chromium": {
-      "version": "1.4.69",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.69.tgz",
-      "integrity": "sha512-0rxK21MqWhN/fVUXNOeBksRlw79Wq26y6R8lxEEL2v7vwzRWbYhXI7Id5msee7/q1NNgu4mG78qaablN2xtfTQ==",
-      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -1054,12 +3601,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -1074,13 +3615,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+      "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint/eslintrc": "^1.4.0",
+        "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -1099,7 +3640,7 @@
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
@@ -1118,29 +3659,19 @@
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
     "eslint-config-prettier": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -1164,35 +3695,20 @@
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.0.tgz",
+      "integrity": "sha512-Hd/F7wz4Mj44Jp0H6Jtty13NcE69GNTY0rVlgTIj1XBnGGVI6UTdDrpE6vqu3AHo07bygq/N+7OH/lgz1emUJw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       }
     },
     "eslint-plugin-prettier": {
@@ -1237,6 +3753,12 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
+    "esmock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-2.1.0.tgz",
+      "integrity": "sha512-8/2+iFfcB5FMJDBWXmXCY/4GSaI8sMCWUmq2laroQc3y9AI53QMm5Ew25DkW9FMaM8dBH8hmvOr2l3qChJ2JgA==",
+      "dev": true
+    },
     "espree": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
@@ -1247,12 +3769,6 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -1292,7 +3808,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -1317,9 +3833,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1346,17 +3862,6 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
       }
     },
     "find-up": {
@@ -1409,7 +3914,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
       "version": "2.3.3",
@@ -1421,16 +3926,10 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -1446,12 +3945,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1464,16 +3957,10 @@
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
-    "get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1502,19 +3989,13 @@
       }
     },
     "globals": {
-      "version": "13.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
       }
-    },
-    "graceful-fs": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -1525,7 +4006,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
     },
     "har-validator": {
       "version": "5.1.5",
@@ -1551,24 +4032,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "hasha": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-      "dev": true,
-      "requires": {
-        "is-stream": "^2.0.0",
-        "type-fest": "^0.8.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1584,7 +4047,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1594,15 +4057,15 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "requires": {
         "ms": "^2.0.0"
       }
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "import-fresh": {
@@ -1618,19 +4081,13 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -1657,9 +4114,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -1668,7 +4125,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -1712,18 +4169,12 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
@@ -1735,63 +4186,19 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
       "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "^2.0.0"
-      }
-    },
-    "istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
-      }
-    },
-    "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
-      "dev": true,
-      "requires": {
-        "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
-      }
     },
     "istanbul-lib-report": {
       "version": "3.0.0",
@@ -1804,29 +4211,10 @@
         "supports-color": "^7.1.0"
       }
     },
-    "istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -1837,12 +4225,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -1857,13 +4239,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -1884,16 +4260,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "jsprim": {
       "version": "1.4.2",
@@ -1941,12 +4308,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -1990,6 +4351,15 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -1997,40 +4367,42 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
-      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
     "mocha": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
-      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",
@@ -2065,23 +4437,6 @@
             "balanced-match": "^1.0.0"
           }
         },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
         "minimatch": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -2105,13 +4460,14 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
         }
       }
-    },
-    "module-alias": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "ms": {
       "version": "2.1.2",
@@ -2131,38 +4487,16 @@
       "dev": true
     },
     "nise": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.2.tgz",
-      "integrity": "sha512-+gQjFi8v+tkfCuSCxfURHLhRhniE/+IaYbIphxAN2JRR9SHKhY8hgXpaXiYfHdw+gcGe4buxgbprBQFab9FkhA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/fake-timers": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "1.8.6",
-              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-              "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            }
-          }
-        }
       }
     },
     "nock": {
@@ -2177,175 +4511,11 @@
         "propagate": "^2.0.0"
       }
     },
-    "node-preload": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-      "dev": true,
-      "requires": {
-        "process-on-spawn": "^1.0.0"
-      }
-    },
-    "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
-      "dev": true
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-      "dev": true,
-      "requires": {
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "caching-transform": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "decamelize": "^1.2.0",
-        "find-cache-dir": "^3.2.0",
-        "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "make-dir": "^3.0.0",
-        "node-preload": "^0.2.1",
-        "p-map": "^3.0.0",
-        "process-on-spawn": "^1.0.0",
-        "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
-        "yargs": "^15.0.2"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -2355,7 +4525,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -2401,33 +4571,6 @@
         "p-limit": "^3.0.2"
       }
     },
-    "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^3.0.0"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
-    "package-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^5.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2446,7 +4589,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -2479,67 +4622,13 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
-    },
-    "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -2548,9 +4637,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -2562,15 +4651,6 @@
         "fast-diff": "^1.1.2"
       }
     },
-    "process-on-spawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.2.0"
-      }
-    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -2578,9 +4658,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -2631,15 +4711,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
-    },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "requires": {
-        "es6-error": "^4.0.1"
-      }
     },
     "request": {
       "version": "2.88.2",
@@ -2696,22 +4767,16 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -2752,9 +4817,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-stable-stringify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
-      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
+      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2762,10 +4827,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -2775,12 +4843,6 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -2812,37 +4874,17 @@
       }
     },
     "sinon": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.0.tgz",
-      "integrity": "sha512-pV97G1GbslaSJoSdy2F2z8uh5F+uPGp3ddOzA4JsBOUBLEQRz2OAqlKGRFTSh2KiqUCmHkzyAeu7R4x1Hx0wwg==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/fake-timers": "10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",
         "supports-color": "^7.2.0"
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-      "dev": true,
-      "requires": {
-        "foreground-child": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "which": "^2.0.1"
       }
     },
     "sprintf-js": {
@@ -2874,7 +4916,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "string-width": {
       "version": "4.2.3",
@@ -2903,12 +4945,6 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -2953,12 +4989,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2985,7 +5015,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2993,7 +5023,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -3016,15 +5046,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3043,10 +5064,21 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
+    "v8-to-istanbul": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -3061,12 +5093,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
     },
     "winston": {
       "version": "3.8.2",
@@ -3122,25 +5148,19 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {
@@ -3159,9 +5179,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yargs-unparser": {

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "openHAB.alexa-smarthome",
+  "name": "openhab-alexa",
   "version": "3.2.3",
   "description": "openHAB skill for Amazon Alexa",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/openhab/openhab-alexa.git"
-  },
+  "license": "EPL-2.0",
   "author": "openHAB",
   "contributors": [
     "Dan Cunningham",
     "Jeremy Setton"
   ],
-  "license": "EPL-2.0",
+  "homepage": "https://github.com/openhab/openhab-alexa",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openhab/openhab-alexa.git"
+  },
   "bugs": {
     "url": "https://github.com/openhab/openhab-alexa/issues"
   },
-  "homepage": "https://github.com/openhab/openhab-alexa",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "format": "prettier --write '**/*.js'",
     "fix": "eslint --fix .",
+    "format": "prettier --write '**/*.js'",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test mocha",
-    "test:coverage": "nyc npm test"
+    "test:coverage": "c8 npm test"
   },
   "dependencies": {
     "agentkeepalive": "^4.2.1",
-    "module-alias": "^2.2.2",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
     "sprintf-js": "^1.1.2",
@@ -36,27 +36,23 @@
   },
   "devDependencies": {
     "ajv": "^6.12.6",
+    "c8": "^7.12.0",
     "chai": "^4.3.7",
     "chai-subset": "^1.6.0",
-    "eslint": "^8.28.0",
+    "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "mocha": "^10.1.0",
+    "esmock": "^2.1.0",
+    "mocha": "^10.2.0",
     "nock": "^13.2.9",
-    "nyc": "^15.1.0",
-    "prettier": "^2.8.0",
-    "sinon": "^15.0.0"
+    "prettier": "^2.8.1",
+    "sinon": "^15.0.1"
   },
   "engines": {
     "node": ">=14.0.0"
   },
-  "mocha": {
-    "recursive": true,
-    "reporter": "spec",
-    "slow": "600"
-  },
-  "nyc": {
+  "c8": {
     "check-coverage": true,
     "lines": 95,
     "statements": 95,
@@ -68,6 +64,18 @@
       "text"
     ]
   },
+  "imports": {
+    "#root/*": "./*",
+    "#alexa/*": "./alexa/*",
+    "#openhab/*": "./openhab/*"
+  },
+  "mocha": {
+    "loader": "esmock",
+    "no-warnings": true,
+    "recursive": true,
+    "reporter": "spec",
+    "slow": "600"
+  },
   "prettier": {
     "printWidth": 120,
     "tabWidth": 2,
@@ -75,10 +83,5 @@
     "singleQuote": true,
     "trailingComma": "none",
     "bracketSpacing": true
-  },
-  "_moduleAliases": {
-    "@root": ".",
-    "@alexa": "alexa",
-    "@openhab": "openhab"
   }
 }

--- a/lambda/test/.eslintrc.json
+++ b/lambda/test/.eslintrc.json
@@ -3,6 +3,6 @@
     "mocha": true
   },
   "rules": {
-    "node/no-unpublished-require": "off"
+    "n/no-unpublished-import": "off"
   }
 }

--- a/lambda/test/alexa/cases/alexa.test.js
+++ b/lambda/test/alexa/cases/alexa.test.js
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { RequestError, StatusCodeError } = require('request-promise-native/errors');
+import { RequestError, StatusCodeError } from 'request-promise-native/errors.js';
 
-module.exports = [
+export default [
   {
     description: 'report state color item',
     directive: {
@@ -592,7 +592,14 @@ module.exports = [
         }
       }
     },
-    items: [{ name: 'mode', state: 'FOO', type: 'String' }],
+    items: [
+      {
+        name: 'mode',
+        state: 'FOO',
+        type: 'String',
+        stateDescription: { pattern: '%d' } // invalid pattern
+      }
+    ],
     expected: {
       alexa: {
         context: {
@@ -1506,8 +1513,8 @@ module.exports = [
     description: 'invalid directive error',
     directive: {
       header: {
-        namespace: 'Alexa',
-        name: 'FooBar'
+        namespace: 'Alexa.Foo',
+        name: 'Bar'
       },
       endpoint: {
         endpointId: 'foobar1',
@@ -1523,7 +1530,7 @@ module.exports = [
           },
           payload: {
             type: 'INVALID_DIRECTIVE',
-            message: 'Unsupported directive Alexa/FooBar'
+            message: 'Unsupported directive Alexa.Foo/Bar'
           }
         }
       }

--- a/lambda/test/alexa/cases/authorization.test.js
+++ b/lambda/test/alexa/cases/authorization.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'grant authorization not supported',
     directive: {

--- a/lambda/test/alexa/cases/brightnessController.test.js
+++ b/lambda/test/alexa/cases/brightnessController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set brightness dimmer item',
     directive: {

--- a/lambda/test/alexa/cases/cameraStreamController.test.js
+++ b/lambda/test/alexa/cases/cameraStreamController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'initialize camera stream',
     directive: {

--- a/lambda/test/alexa/cases/channelController.test.js
+++ b/lambda/test/alexa/cases/channelController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'change channel by number',
     directive: {

--- a/lambda/test/alexa/cases/colorController.test.js
+++ b/lambda/test/alexa/cases/colorController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set color',
     directive: {

--- a/lambda/test/alexa/cases/colorTemperatureController.test.js
+++ b/lambda/test/alexa/cases/colorTemperatureController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set color temperature dimmer item',
     directive: {

--- a/lambda/test/alexa/cases/discovery/activity.test.js
+++ b/lambda/test/alexa/cases/discovery/activity.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'activity',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/airConditioner.test.js
+++ b/lambda/test/alexa/cases/discovery/airConditioner.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'air conditioner',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/airFreshener.test.js
+++ b/lambda/test/alexa/cases/discovery/airFreshener.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'air freshener',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/airPurifier.test.js
+++ b/lambda/test/alexa/cases/discovery/airPurifier.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'air purifier',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/automobile.test.js
+++ b/lambda/test/alexa/cases/discovery/automobile.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'automobile',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/automobileAccessory.test.js
+++ b/lambda/test/alexa/cases/discovery/automobileAccessory.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'automobile accessory',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/blind.test.js
+++ b/lambda/test/alexa/cases/discovery/blind.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'blind',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/bluetoothSpeaker.test.js
+++ b/lambda/test/alexa/cases/discovery/bluetoothSpeaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'bluetooth speaker',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/camera.test.js
+++ b/lambda/test/alexa/cases/discovery/camera.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'camera',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/christmasTree.test.js
+++ b/lambda/test/alexa/cases/discovery/christmasTree.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'christmas tree',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/coffeeMaker.test.js
+++ b/lambda/test/alexa/cases/discovery/coffeeMaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'coffee maker',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/computer.test.js
+++ b/lambda/test/alexa/cases/discovery/computer.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'computer',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/contactSensor.test.js
+++ b/lambda/test/alexa/cases/discovery/contactSensor.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'contact sensor',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/dishwasher.test.js
+++ b/lambda/test/alexa/cases/discovery/dishwasher.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'dishwasher',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/door.test.js
+++ b/lambda/test/alexa/cases/discovery/door.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'door',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/doorbell.test.js
+++ b/lambda/test/alexa/cases/discovery/doorbell.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'doorbell',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/dryer.test.js
+++ b/lambda/test/alexa/cases/discovery/dryer.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'dryer',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/fan.test.js
+++ b/lambda/test/alexa/cases/discovery/fan.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'fan',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/gameConsole.test.js
+++ b/lambda/test/alexa/cases/discovery/gameConsole.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'game console',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/headphones.test.js
+++ b/lambda/test/alexa/cases/discovery/headphones.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'headphones',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/hub.test.js
+++ b/lambda/test/alexa/cases/discovery/hub.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'hub',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/laptop.test.js
+++ b/lambda/test/alexa/cases/discovery/laptop.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'laptop',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/light.test.js
+++ b/lambda/test/alexa/cases/discovery/light.test.js
@@ -11,7 +11,11 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+
+const uuid = uuidv4();
+
+export default {
   description: 'light',
   items: [
     {
@@ -198,7 +202,7 @@ module.exports = {
   ],
   settings: {
     runtime: {
-      uuid: '00000000-0000-0000-0000-000000000000',
+      uuid,
       version: '2'
     }
   },
@@ -240,7 +244,7 @@ module.exports = {
         manufacturer: 'openHAB',
         model: 'Color light3',
         softwareVersion: '2',
-        customIdentifier: 'ca60d77f-479a-5fb4-9586-38d5adb736de'
+        customIdentifier: uuidv5('light3', uuid)
       }
     },
     light4: {

--- a/lambda/test/alexa/cases/discovery/lock.test.js
+++ b/lambda/test/alexa/cases/discovery/lock.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'lock',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/microwave.test.js
+++ b/lambda/test/alexa/cases/discovery/microwave.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'microwave',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/mobilePhone.test.js
+++ b/lambda/test/alexa/cases/discovery/mobilePhone.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'mobile phone',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/motionSensor.test.js
+++ b/lambda/test/alexa/cases/discovery/motionSensor.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'motion sensor',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/musicSystem.test.js
+++ b/lambda/test/alexa/cases/discovery/musicSystem.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'music system',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/networkHardware.test.js
+++ b/lambda/test/alexa/cases/discovery/networkHardware.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'network hardware',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/other.test.js
+++ b/lambda/test/alexa/cases/discovery/other.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'other',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/outlet.test.js
+++ b/lambda/test/alexa/cases/discovery/outlet.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'outlet plug',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/oven.test.js
+++ b/lambda/test/alexa/cases/discovery/oven.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'oven',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/phone.test.js
+++ b/lambda/test/alexa/cases/discovery/phone.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'phone',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/printer.test.js
+++ b/lambda/test/alexa/cases/discovery/printer.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'printer',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/router.test.js
+++ b/lambda/test/alexa/cases/discovery/router.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'router',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/scene.test.js
+++ b/lambda/test/alexa/cases/discovery/scene.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'scene',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/screen.test.js
+++ b/lambda/test/alexa/cases/discovery/screen.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'screen',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/securityPanel.test.js
+++ b/lambda/test/alexa/cases/discovery/securityPanel.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'security panel',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/securitySystem.test.js
+++ b/lambda/test/alexa/cases/discovery/securitySystem.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'security system',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/shutter.test.js
+++ b/lambda/test/alexa/cases/discovery/shutter.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'shutter',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/slowCooker.test.js
+++ b/lambda/test/alexa/cases/discovery/slowCooker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'slow cooker',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/speaker.test.js
+++ b/lambda/test/alexa/cases/discovery/speaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'speaker',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/stepSpeaker.test.js
+++ b/lambda/test/alexa/cases/discovery/stepSpeaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'step speaker',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/streamingDevice.test.js
+++ b/lambda/test/alexa/cases/discovery/streamingDevice.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'streming device',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/switch.test.js
+++ b/lambda/test/alexa/cases/discovery/switch.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'switch',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/tablet.test.js
+++ b/lambda/test/alexa/cases/discovery/tablet.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'tablet',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/television.test.js
+++ b/lambda/test/alexa/cases/discovery/television.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'television',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/temperatureSensor.test.js
+++ b/lambda/test/alexa/cases/discovery/temperatureSensor.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'temperature sensor',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/thermostat.test.js
+++ b/lambda/test/alexa/cases/discovery/thermostat.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'thermostat',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/vacuumCleaner.test.js
+++ b/lambda/test/alexa/cases/discovery/vacuumCleaner.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'vacuum cleaner',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/washer.test.js
+++ b/lambda/test/alexa/cases/discovery/washer.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'washer',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/waterHeater.test.js
+++ b/lambda/test/alexa/cases/discovery/waterHeater.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'water heater',
   items: [
     {

--- a/lambda/test/alexa/cases/discovery/wearable.test.js
+++ b/lambda/test/alexa/cases/discovery/wearable.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
+export default {
   description: 'wearable',
   items: [
     {

--- a/lambda/test/alexa/cases/equalizerController.test.js
+++ b/lambda/test/alexa/cases/equalizerController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set bands',
     directive: {
@@ -101,6 +101,41 @@ module.exports = [
       },
       openhab: {
         commands: [{ name: 'equalizerBass', value: -2 }]
+      }
+    }
+  },
+  {
+    description: 'set bands no properties invalid value error',
+    directive: {
+      header: {
+        namespace: 'Alexa.EqualizerController',
+        name: 'SetBands'
+      },
+      endpoint: {
+        endpointId: 'gSpeaker',
+        cookie: {
+          // workaround bug introduced by previous version
+          propertyMap: JSON.stringify({
+            EqualizerController: {}
+          })
+        }
+      },
+      payload: {
+        bands: [{ name: 'BASS', level: -2 }]
+      }
+    },
+    expected: {
+      alexa: {
+        event: {
+          header: {
+            namespace: 'Alexa',
+            name: 'ErrorResponse'
+          },
+          payload: {
+            type: 'INVALID_VALUE',
+            message: 'No equalizer bands properties defined.'
+          }
+        }
       }
     }
   },
@@ -402,7 +437,42 @@ module.exports = [
     }
   },
   {
-    description: 'adjust bands invalid value error',
+    description: 'adjust bands no properties invalid value error',
+    directive: {
+      header: {
+        namespace: 'Alexa.EqualizerController',
+        name: 'AdjustBands'
+      },
+      endpoint: {
+        endpointId: 'gSpeaker',
+        cookie: {
+          // workaround bug introduced by previous version
+          propertyMap: JSON.stringify({
+            EqualizerController: {}
+          })
+        }
+      },
+      payload: {
+        bands: [{ name: 'BASS', levelDirection: 'DOWN' }]
+      }
+    },
+    expected: {
+      alexa: {
+        event: {
+          header: {
+            namespace: 'Alexa',
+            name: 'ErrorResponse'
+          },
+          payload: {
+            type: 'INVALID_VALUE',
+            message: 'No equalizer bands properties defined.'
+          }
+        }
+      }
+    }
+  },
+  {
+    description: 'adjust bands not retrievable invalid value error',
     directive: {
       header: {
         namespace: 'Alexa.EqualizerController',
@@ -585,7 +655,42 @@ module.exports = [
     }
   },
   {
-    description: 'set mode invalid value error',
+    description: 'set mode no property invalid value error',
+    directive: {
+      header: {
+        namespace: 'Alexa.EqualizerController',
+        name: 'SetMode'
+      },
+      endpoint: {
+        endpointId: 'gSpeaker',
+        cookie: {
+          // workaround bug introduced by previous version
+          propertyMap: JSON.stringify({
+            EqualizerController: {}
+          })
+        }
+      },
+      payload: {
+        mode: 'MOVIE'
+      }
+    },
+    expected: {
+      alexa: {
+        event: {
+          header: {
+            namespace: 'Alexa',
+            name: 'ErrorResponse'
+          },
+          payload: {
+            type: 'INVALID_VALUE',
+            message: 'No equalizer mode property defined.'
+          }
+        }
+      }
+    }
+  },
+  {
+    description: 'set mode not supported invalid value error',
     directive: {
       header: {
         namespace: 'Alexa.EqualizerController',

--- a/lambda/test/alexa/cases/index.js
+++ b/lambda/test/alexa/cases/index.js
@@ -11,86 +11,161 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = {
-  Alexa: [require('./alexa.test.js')],
-  Authorization: [require('./authorization.test.js')],
-  BrightnessController: [require('./brightnessController.test.js')],
-  CameraStreamController: [require('./cameraStreamController.test.js')],
-  ChannelController: [require('./channelController.test.js')],
-  ColorController: [require('./colorController.test.js')],
-  ColorTemperatureController: [require('./colorTemperatureController.test.js')],
+import alexTest from './alexa.test.js';
+import authorizationTest from './authorization.test.js';
+import brightnessControllerTest from './brightnessController.test.js';
+import cameraStreamControllerTest from './cameraStreamController.test.js';
+import channelControllerTest from './channelController.test.js';
+import colorControllerTest from './colorController.test.js';
+import colorTemperatureControllerTest from './colorTemperatureController.test.js';
+import discoveryActivityTest from './discovery/activity.test.js';
+import discoveryAirConditionerTest from './discovery/airConditioner.test.js';
+import discoveryAirFreshenerTest from './discovery/airFreshener.test.js';
+import discoveryAirPurifierTest from './discovery/airPurifier.test.js';
+import discoveryAutomobileTest from './discovery/automobile.test.js';
+import discoveryAutomobileAccessoryTest from './discovery/automobileAccessory.test.js';
+import discoveryBlindTest from './discovery/blind.test.js';
+import discoveryBluetoothSpeakerTest from './discovery/bluetoothSpeaker.test.js';
+import discoveryCameraTest from './discovery/camera.test.js';
+import discoveryChristmasTreeTest from './discovery/christmasTree.test.js';
+import discoveryCoffeeMakerTest from './discovery/coffeeMaker.test.js';
+import discoveryComputerTest from './discovery/computer.test.js';
+import discoveryContactSensorTest from './discovery/contactSensor.test.js';
+import discoveryDishwasherTest from './discovery/dishwasher.test.js';
+import discoveryDoorTest from './discovery/door.test.js';
+import discoveryDoorbellTest from './discovery/doorbell.test.js';
+import discoveryDryerTest from './discovery/dryer.test.js';
+import discoveryFanTest from './discovery/fan.test.js';
+import discoveryGameConsoleTest from './discovery/gameConsole.test.js';
+import discoveryHeadphonesTest from './discovery/headphones.test.js';
+import discoveryHubTest from './discovery/hub.test.js';
+import discoveryLaptopTest from './discovery/laptop.test.js';
+import discoveryLightTest from './discovery/light.test.js';
+import discoveryLockTest from './discovery/lock.test.js';
+import discoveryMicrowaveTest from './discovery/microwave.test.js';
+import discoveryMobilePhoneTest from './discovery/mobilePhone.test.js';
+import discoveryMotionSensorTest from './discovery/motionSensor.test.js';
+import discoveryMusicSystemTest from './discovery/musicSystem.test.js';
+import discoveryNetworkHardwareTest from './discovery/networkHardware.test.js';
+import discoveryOtherTest from './discovery/other.test.js';
+import discoveryOutletTest from './discovery/outlet.test.js';
+import discoveryOvenTest from './discovery/oven.test.js';
+import discoveryPhoneTest from './discovery/phone.test.js';
+import discoveryPrinterTest from './discovery/printer.test.js';
+import discoveryRouterTest from './discovery/router.test.js';
+import discoverySceneTest from './discovery/scene.test.js';
+import discoveryScreenTest from './discovery/screen.test.js';
+import discoverySecurityPanelTest from './discovery/securityPanel.test.js';
+import discoverySecuritySystemTest from './discovery/securitySystem.test.js';
+import discoveryShutterTest from './discovery/shutter.test.js';
+import discoverySlowCookerTest from './discovery/slowCooker.test.js';
+import discoverySpeakerTest from './discovery/speaker.test.js';
+import discoveryStepSpeakerTest from './discovery/stepSpeaker.test.js';
+import discoveryStreamingDeviceTest from './discovery/streamingDevice.test.js';
+import discoverySwitchTest from './discovery/switch.test.js';
+import discoveryTabletTest from './discovery/tablet.test.js';
+import discoveryTelevisionTest from './discovery/television.test.js';
+import discoveryTemperatureSensorTest from './discovery/temperatureSensor.test.js';
+import discoveryThermostatTest from './discovery/thermostat.test.js';
+import discoveryVacuumCleanerTest from './discovery/vacuumCleaner.test.js';
+import discoveryWasherTest from './discovery/washer.test.js';
+import discoveryWaterHeaterTest from './discovery/waterHeater.test.js';
+import discoveryWearableTest from './discovery/wearable.test.js';
+import equalizerControllerTest from './equalizerController.test.js';
+import inputControllerTest from './inputController.test.js';
+import lockControllerTest from './lockController.test.js';
+import modeControllerTest from './modeController.test.js';
+import networkingAccessControllerTest from './networkingAccessController.test.js';
+import percentageControllerTest from './percentageController.test.js';
+import playbackControllerTest from './playbackController.test.js';
+import powerControllerTest from './powerController.test.js';
+import powerLevelControllerTest from './powerLevelController.test.js';
+import rangeControllerTest from './rangeController.test.js';
+import sceneControllerTest from './sceneController.test.js';
+import securityPanelControllerTest from './securityPanelController.test.js';
+import speakerTest from './speaker.test.js';
+import stepSpeakerTest from './stepSpeaker.test.js';
+import thermostatControllerModeTest from './thermostatControllerMode.test.js';
+import thermostatControllerTemperatureTest from './thermostatControllerTemperature.test.js';
+import toggleControllerTest from './toggleController.test.js';
+
+export default {
+  Alexa: [alexTest],
+  Authorization: [authorizationTest],
+  BrightnessController: [brightnessControllerTest],
+  CameraStreamController: [cameraStreamControllerTest],
+  ChannelController: [channelControllerTest],
+  ColorController: [colorControllerTest],
+  ColorTemperatureController: [colorTemperatureControllerTest],
   Discovery: [
-    require('./discovery/activity.test.js'),
-    require('./discovery/airConditioner.test.js'),
-    require('./discovery/airFreshener.test.js'),
-    require('./discovery/airPurifier.test.js'),
-    require('./discovery/automobile.test.js'),
-    require('./discovery/automobileAccessory.test.js'),
-    require('./discovery/blind.test.js'),
-    require('./discovery/bluetoothSpeaker.test.js'),
-    require('./discovery/camera.test.js'),
-    require('./discovery/christmasTree.test.js'),
-    require('./discovery/coffeeMaker.test.js'),
-    require('./discovery/computer.test.js'),
-    require('./discovery/contactSensor.test.js'),
-    require('./discovery/dishwasher.test.js'),
-    require('./discovery/door.test.js'),
-    require('./discovery/doorbell.test.js'),
-    require('./discovery/dryer.test.js'),
-    require('./discovery/fan.test.js'),
-    require('./discovery/gameConsole.test.js'),
-    require('./discovery/headphones.test.js'),
-    require('./discovery/hub.test.js'),
-    require('./discovery/laptop.test.js'),
-    require('./discovery/light.test.js'),
-    require('./discovery/lock.test.js'),
-    require('./discovery/microwave.test.js'),
-    require('./discovery/mobilePhone.test.js'),
-    require('./discovery/motionSensor.test.js'),
-    require('./discovery/musicSystem.test.js'),
-    require('./discovery/networkHardware.test.js'),
-    require('./discovery/other.test.js'),
-    require('./discovery/outlet.test.js'),
-    require('./discovery/oven.test.js'),
-    require('./discovery/phone.test.js'),
-    require('./discovery/printer.test.js'),
-    require('./discovery/router.test.js'),
-    require('./discovery/scene.test.js'),
-    require('./discovery/screen.test.js'),
-    require('./discovery/securityPanel.test.js'),
-    require('./discovery/securitySystem.test.js'),
-    require('./discovery/shutter.test.js'),
-    require('./discovery/slowCooker.test.js'),
-    require('./discovery/speaker.test.js'),
-    require('./discovery/stepSpeaker.test.js'),
-    require('./discovery/streamingDevice.test.js'),
-    require('./discovery/switch.test.js'),
-    require('./discovery/tablet.test.js'),
-    require('./discovery/television.test.js'),
-    require('./discovery/temperatureSensor.test.js'),
-    require('./discovery/thermostat.test.js'),
-    require('./discovery/vacuumCleaner.test.js'),
-    require('./discovery/washer.test.js'),
-    require('./discovery/waterHeater.test.js'),
-    require('./discovery/wearable.test.js')
+    discoveryActivityTest,
+    discoveryAirConditionerTest,
+    discoveryAirFreshenerTest,
+    discoveryAirPurifierTest,
+    discoveryAutomobileTest,
+    discoveryAutomobileAccessoryTest,
+    discoveryBlindTest,
+    discoveryBluetoothSpeakerTest,
+    discoveryCameraTest,
+    discoveryChristmasTreeTest,
+    discoveryCoffeeMakerTest,
+    discoveryComputerTest,
+    discoveryContactSensorTest,
+    discoveryDishwasherTest,
+    discoveryDoorTest,
+    discoveryDoorbellTest,
+    discoveryDryerTest,
+    discoveryFanTest,
+    discoveryGameConsoleTest,
+    discoveryHeadphonesTest,
+    discoveryHubTest,
+    discoveryLaptopTest,
+    discoveryLightTest,
+    discoveryLockTest,
+    discoveryMicrowaveTest,
+    discoveryMobilePhoneTest,
+    discoveryMotionSensorTest,
+    discoveryMusicSystemTest,
+    discoveryNetworkHardwareTest,
+    discoveryOtherTest,
+    discoveryOutletTest,
+    discoveryOvenTest,
+    discoveryPhoneTest,
+    discoveryPrinterTest,
+    discoveryRouterTest,
+    discoverySceneTest,
+    discoveryScreenTest,
+    discoverySecurityPanelTest,
+    discoverySecuritySystemTest,
+    discoveryShutterTest,
+    discoverySlowCookerTest,
+    discoverySpeakerTest,
+    discoveryStepSpeakerTest,
+    discoveryStreamingDeviceTest,
+    discoverySwitchTest,
+    discoveryTabletTest,
+    discoveryTelevisionTest,
+    discoveryTemperatureSensorTest,
+    discoveryThermostatTest,
+    discoveryVacuumCleanerTest,
+    discoveryWasherTest,
+    discoveryWaterHeaterTest,
+    discoveryWearableTest
   ],
-  EqualizerController: [require('./equalizerController.test.js')],
-  InputController: [require('./inputController.test.js')],
-  LockController: [require('./lockController.test.js')],
-  ModeController: [require('./modeController.test.js')],
-  NetworkingAccessController: [require('./networkingAccessController.test.js')],
-  PercentageController: [require('./percentageController.test.js')],
-  PlaybackController: [require('./playbackController.test.js')],
-  PowerController: [require('./powerController.test.js')],
-  PowerLevelController: [require('./powerLevelController.test.js')],
-  RangeController: [require('./rangeController.test.js')],
-  SceneController: [require('./sceneController.test.js')],
-  SecurityPanelController: [require('./securityPanelController.test.js')],
-  Speaker: [require('./speaker.test.js')],
-  StepSpeaker: [require('./stepSpeaker.test.js')],
-  ThermostatController: [
-    require('./thermostatControllerMode.test.js'),
-    require('./thermostatControllerTemperature.test.js')
-  ],
-  ToggleController: [require('./toggleController.test.js')]
+  EqualizerController: [equalizerControllerTest],
+  InputController: [inputControllerTest],
+  LockController: [lockControllerTest],
+  ModeController: [modeControllerTest],
+  NetworkingAccessController: [networkingAccessControllerTest],
+  PercentageController: [percentageControllerTest],
+  PlaybackController: [playbackControllerTest],
+  PowerController: [powerControllerTest],
+  PowerLevelController: [powerLevelControllerTest],
+  RangeController: [rangeControllerTest],
+  SceneController: [sceneControllerTest],
+  SecurityPanelController: [securityPanelControllerTest],
+  Speaker: [speakerTest],
+  StepSpeaker: [stepSpeakerTest],
+  ThermostatController: [thermostatControllerModeTest, thermostatControllerTemperatureTest],
+  ToggleController: [toggleControllerTest]
 };

--- a/lambda/test/alexa/cases/inputController.test.js
+++ b/lambda/test/alexa/cases/inputController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'select input',
     directive: {

--- a/lambda/test/alexa/cases/lockController.test.js
+++ b/lambda/test/alexa/cases/lockController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'lock',
     directive: {

--- a/lambda/test/alexa/cases/modeController.test.js
+++ b/lambda/test/alexa/cases/modeController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set mode',
     directive: {

--- a/lambda/test/alexa/cases/networkingAccessController.test.js
+++ b/lambda/test/alexa/cases/networkingAccessController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set network access',
     directive: {

--- a/lambda/test/alexa/cases/percentageController.test.js
+++ b/lambda/test/alexa/cases/percentageController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set percentage',
     directive: {

--- a/lambda/test/alexa/cases/playbackController.test.js
+++ b/lambda/test/alexa/cases/playbackController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'play request',
     directive: {

--- a/lambda/test/alexa/cases/powerController.test.js
+++ b/lambda/test/alexa/cases/powerController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'turn on power switch item',
     directive: {

--- a/lambda/test/alexa/cases/powerLevelController.test.js
+++ b/lambda/test/alexa/cases/powerLevelController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set power level',
     directive: {

--- a/lambda/test/alexa/cases/rangeController.test.js
+++ b/lambda/test/alexa/cases/rangeController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set range value dimmer item',
     directive: {

--- a/lambda/test/alexa/cases/sceneController.test.js
+++ b/lambda/test/alexa/cases/sceneController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'activate scene',
     directive: {

--- a/lambda/test/alexa/cases/securityPanelController.test.js
+++ b/lambda/test/alexa/cases/securityPanelController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'arm away no delay string item',
     directive: {

--- a/lambda/test/alexa/cases/speaker.test.js
+++ b/lambda/test/alexa/cases/speaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set volume',
     directive: {

--- a/lambda/test/alexa/cases/stepSpeaker.test.js
+++ b/lambda/test/alexa/cases/stepSpeaker.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'adjust volume steps',
     directive: {

--- a/lambda/test/alexa/cases/thermostatControllerMode.test.js
+++ b/lambda/test/alexa/cases/thermostatControllerMode.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set thermostat mode string state map parameters',
     directive: {

--- a/lambda/test/alexa/cases/thermostatControllerTemperature.test.js
+++ b/lambda/test/alexa/cases/thermostatControllerTemperature.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'set target temperature triple mode',
     directive: {

--- a/lambda/test/alexa/cases/toggleController.test.js
+++ b/lambda/test/alexa/cases/toggleController.test.js
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-module.exports = [
+export default [
   {
     description: 'turn on toggle state switch item',
     directive: {

--- a/lambda/test/alexa/chai.js
+++ b/lambda/test/alexa/chai.js
@@ -11,9 +11,11 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-require('module-alias/register');
-const Ajv = require('ajv');
-const { decompressJSON } = require('@root/utils');
+import Ajv from 'ajv';
+import { createRequire } from 'node:module';
+import { decompressJSON } from '#root/utils.js';
+
+const require = createRequire(import.meta.url);
 
 // Initialize the alexa smart home message json schema draft v4 validator
 const validate = new Ajv({ schemaId: 'auto', unknownFormats: ['double', 'int32'] })
@@ -187,7 +189,7 @@ function getCapabilitiesSemantics(capabilities) {
  * Adds smarthome related chai assertions
  * @param  {Object} chai
  */
-module.exports = function (chai) {
+export default function (chai) {
   const { Assertion } = chai;
 
   /**
@@ -250,4 +252,4 @@ module.exports = function (chai) {
       `Schema Validation Failed\nData: ${JSON.stringify(this._obj)}\n\nErrors: ${JSON.stringify(validate.errors)}`
     );
   });
-};
+}

--- a/lambda/test/openhab.test.js
+++ b/lambda/test/openhab.test.js
@@ -11,14 +11,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-require('module-alias/register');
-const { expect } = require('chai');
-const sinon = require('sinon');
-const nock = require('nock');
-const fs = require('fs');
-const Agent = require('agentkeepalive');
-const { v4: uuidv4 } = require('uuid');
-const OpenHAB = require('@openhab');
+import { expect } from 'chai';
+import sinon from 'sinon';
+import nock from 'nock';
+import fs from 'fs';
+import Agent from 'agentkeepalive';
+import { v4 as uuidv4 } from 'uuid';
+import OpenHAB from '#openhab/index.js';
 
 describe('OpenHAB Tests', () => {
   // set default environment

--- a/lambda/test/skill.test.js
+++ b/lambda/test/skill.test.js
@@ -11,19 +11,22 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-require('module-alias/register');
-const { expect } = require('chai');
-const sinon = require('sinon');
-const log = require('@root/log');
-const skill = require('@root');
-const AlexaSmarthome = require('@alexa/smarthome');
+import { expect } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+import log from '#root/log.js';
 
 describe('Skill Event Tests', () => {
-  let smarthome;
+  let smarthomeStub, skill;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // set stub environment
-    smarthome = sinon.stub(AlexaSmarthome, 'handleRequest');
+    smarthomeStub = sinon.stub();
+    skill = await esmock('#root/index.js', {
+      '#alexa/smarthome/index.js': {
+        handleRequest: smarthomeStub
+      }
+    });
   });
 
   afterEach(() => {
@@ -45,8 +48,8 @@ describe('Skill Event Tests', () => {
       };
       // run test
       await skill.handler(event);
-      expect(smarthome.called).to.be.true;
-      expect(smarthome.firstCall.args).to.deep.equal([event]);
+      expect(smarthomeStub.called).to.be.true;
+      expect(smarthomeStub.firstCall.args).to.deep.equal([event]);
     });
 
     it('payload version 2', async () => {
@@ -61,7 +64,7 @@ describe('Skill Event Tests', () => {
       const logWarn = sinon.stub(log, 'warn');
       // run test
       await skill.handler(event);
-      expect(smarthome.called).to.be.false;
+      expect(smarthomeStub.called).to.be.false;
       expect(logWarn.called).to.be.true;
       expect(logWarn.firstCall.args).to.deep.equal(['Unsupported event:', event]);
     });

--- a/lambda/test/utils.test.js
+++ b/lambda/test/utils.test.js
@@ -11,9 +11,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-require('module-alias/register');
-const { expect } = require('chai');
-const {
+import { expect } from 'chai';
+import {
   clamp,
   compressJSON,
   decompressJSON,
@@ -21,7 +20,7 @@ const {
   isMACAddress,
   parseUrl,
   stripPunctuation
-} = require('@root/utils');
+} from '#root/utils.js';
 
 describe('Utilities Tests', () => {
   describe('clamp', () => {

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -11,92 +11,86 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const { deflateSync, inflateSync } = require('zlib');
+import { deflateSync, inflateSync } from 'zlib';
 
 /**
- * Defines utility functions
- * @type {Object}
+ * Returns clamp value
+ * @param  {Number} value
+ * @param  {Number} minValue
+ * @param  {Number} maxValue
+ * @return {Number}
  */
-module.exports = {
-  /**
-   * Returns clamp value
-   * @param  {Number} value
-   * @param  {Number} minValue
-   * @param  {Number} maxValue
-   * @return {Number}
-   */
-  clamp: (value, minValue, maxValue) => {
-    return Math.min(Math.max(value, minValue), maxValue);
-  },
+export const clamp = (value, minValue, maxValue) => {
+  return Math.min(Math.max(value, minValue), maxValue);
+};
 
-  /**
-   * Returns compressed json string
-   * @param  {Object} object
-   * @return {String}
-   */
-  compressJSON: (object) => {
-    return deflateSync(Buffer.from(JSON.stringify(object))).toString('base64');
-  },
+/**
+ * Returns compressed json string
+ * @param  {Object} object
+ * @return {String}
+ */
+export const compressJSON = (object) => {
+  return deflateSync(Buffer.from(JSON.stringify(object))).toString('base64');
+};
 
-  /**
-   * Returns decompressed json object
-   * @param  {String} string
-   * @return {Object}
-   */
-  decompressJSON: (string) => {
-    try {
-      return JSON.parse(inflateSync(Buffer.from(string, 'base64')).toString());
-    } catch {
-      return JSON.parse(string);
-    }
-  },
-
-  /**
-   * Returns decamelize formatted string
-   * @param  {String} string
-   * @param  {String} separator
-   * @return {String}
-   */
-  decamelize: (string, separator = '_') => {
-    return string
-      .replace(/([a-z\d])([A-Z])/g, '$1' + separator + '$2')
-      .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + separator + '$2')
-      .toLowerCase();
-  },
-
-  /**
-   * Returns if given string is a mac address
-   * @param  {String}  string
-   * @return {Boolean}
-   */
-  isMACAddress: (string) => {
-    return /^([0-9a-fA-F]{2}(-|:)){7}[0-9a-fA-F]{2}$|^([0-9a-fA-F]{2}(-|:)){5}[0-9a-fA-F]{2}$/.test(string);
-  },
-
-  /**
-   * Returns parsed url object
-   * @param  {String} url
-   * @param  {String} base
-   * @return {Object}
-   */
-  parseUrl: (url, base) => {
-    try {
-      const parsedUrl = new URL(url);
-      return base ? new URL(parsedUrl.pathname, base) : parsedUrl;
-    } catch {
-      return undefined;
-    }
-  },
-
-  /**
-   * Returns formatted string without punctuation characters
-   * @param  {String} string
-   * @return {String}
-   */
-  stripPunctuation: (string) => {
-    return string
-      .replace(/[!"#$%&()*+,-./:;<=>?@[\\\]^_`{|}~°]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim();
+/**
+ * Returns decompressed json object
+ * @param  {String} string
+ * @return {Object}
+ */
+export const decompressJSON = (string) => {
+  try {
+    return JSON.parse(inflateSync(Buffer.from(string, 'base64')).toString());
+  } catch {
+    return JSON.parse(string);
   }
+};
+
+/**
+ * Returns decamelize formatted string
+ * @param  {String} string
+ * @param  {String} separator
+ * @return {String}
+ */
+export const decamelize = (string, separator = '_') => {
+  return string
+    .replace(/([a-z\d])([A-Z])/g, '$1' + separator + '$2')
+    .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1' + separator + '$2')
+    .toLowerCase();
+};
+
+/**
+ * Returns if given string is a mac address
+ * @param  {String}  string
+ * @return {Boolean}
+ */
+export const isMACAddress = (string) => {
+  return /^([0-9a-fA-F]{2}(-|:)){7}[0-9a-fA-F]{2}$|^([0-9a-fA-F]{2}(-|:)){5}[0-9a-fA-F]{2}$/.test(string);
+};
+
+/**
+ * Returns parsed url object
+ * @param  {String} url
+ * @param  {String} base
+ * @return {Object}
+ */
+export const parseUrl = (url, base) => {
+  try {
+    const parsedUrl = new URL(url);
+    return base ? new URL(parsedUrl.pathname, base) : parsedUrl;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Returns formatted string without punctuation characters
+ * @param  {String} string
+ * @return {String}
+ */
+export const stripPunctuation = (string) => {
+  return string
+    .replace(/[!"#$%&()*+,-./:;<=>?@[\\\]^_`{|}~°]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 };


### PR DESCRIPTION
AWS Lambda started to [support ES modules](https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/) from nodejs14 since the beginning of the year.

While looking at replacing the deprecated [`request`](https://www.npmjs.com/package/request) http client package, there is an increasingly amount of maintained packages that are going ESM support only. I ended making the conversion to test some of the latest http client packages such as [`got`](https://www.npmjs.com/package/got) or [`node-fetch`](https://www.npmjs.com/package/node-fetch). In the end, I settled with [`axios`](https://www.npmjs.com/package/axios) for the time being since it requires the least amount of changes in our codebase (Will be part of a separate PR). I am curious to see how the native Fetch API evolves.