### PR TITLE
Set skill distribution mode to public by default

### DIFF
--- a/.github/scripts/generateDeployConfig.js
+++ b/.github/scripts/generateDeployConfig.js
@@ -118,8 +118,6 @@ function updateSkillManifest() {
   const schema = loadSchema(SKILL_MANIFEST_FILE);
   // Extract publishing information from manifest
   const { publishingInformation } = schema.manifest;
-  // Set publishing distribution mode as public
-  publishingInformation.distributionMode = 'PUBLIC';
   // Set publishing testing instructions username and passowrd
   publishingInformation.testingInstructions = publishingInformation.testingInstructions
     .replace('%TESTING_USERNAME%', process.env.TESTING_USERNAME)

--- a/skill-package/skill.json
+++ b/skill-package/skill.json
@@ -486,7 +486,7 @@
       },
       "distributionCountries": [],
       "isAvailableWorldwide": true,
-      "distributionMode": "PRIVATE",
+      "distributionMode": "PUBLIC",
       "testingInstructions": "A demo account has been setup on our cloud service myopenhab.org for this skill:\n\nUsername: %TESTING_USERNAME%\nPassword: %TESTING_PASSWORD%\n\nOnce the skill is linked to our cloud service and discovery is run, it should find a few lights, a lock, a speaker, a thermostat and a window blind.",
       "category": "SMART_HOME"
     },


### PR DESCRIPTION
Due to the integration with Alexa for Business no longer available as of March 2023, the skill distribution mode needs to be set to `PUBLIC` regardless if the skill will be published. An action required message is now displayed in the Alexa Developer console for any skill currently set to `PRIVATE` to be set to `PUBLIC`.