### PR TITLE
Require drafted release to be manually published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
         git commit -a -m "Bump version to ${{ steps.pkg-version.outputs.version }}"
         git push
 
-  publish:
-    name: Release Publishing
+  draft:
+    name: Release Drafting
     runs-on: ubuntu-latest
     needs: pkg-update
 
@@ -55,11 +55,10 @@ jobs:
       pull-requests: write
 
     steps:
-    - name: Draft and publish a new release
+    - name: Draft a new release
       uses: release-drafter/release-drafter@v5
       with:
         version: ${{ needs.pkg-update.outputs.version }}
         prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
-        publish: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By [design](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), a `published` event generated through GitHub Actions using the `GITHUB_TOKEN` doesn't trigger any new workflow preventing the deployment workflow from running.

Requiring the drafted release to be manually published will ensure that event will get triggered. Additionally, it allows us to go over the release notes before publishing the release.