### PR TITLE
Fix github action submit skill for certification config

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -78,3 +78,5 @@ jobs:
         ASK_ACCESS_TOKEN: ${{ secrets.ASK_ACCESS_TOKEN }}
         ASK_REFRESH_TOKEN: ${{ secrets.ASK_REFRESH_TOKEN }}
         ASK_VENDOR_ID: ${{ secrets.ASK_VENDOR_ID }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
ASK CLI requires AWS credentials to be defined otherwise it falls back to the local config file. 

Related to #688 

