### PR TITLE
Set response timeout at client level

### DIFF
--- a/lambda/openhab/index.js
+++ b/lambda/openhab/index.js
@@ -225,9 +225,9 @@ export default class OpenHAB {
       },
       httpsAgent: new HttpsAgent({
         // Set keep-alive free socket to timeout after 45s of inactivity
-        freeSocketTimeout: 45000,
-        timeout: parseInt(timeout)
-      })
+        freeSocketTimeout: 45000
+      }),
+      timeout: parseInt(timeout)
     });
 
     // Add authentication options


### PR DESCRIPTION
Axios doesn't enforce the response timeout when configured in the custom https agent. Setting at the client level instead to ensure it is enforced.